### PR TITLE
dumper: (PE) add PE_DEBUG_DIRECTORY with -S g flag

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -134,6 +134,7 @@ int clipage(CLIPage h) {
 		"h .. Show headers\n"~
 		"s .. Show sections\n"~
 		"i .. Show imports\n"~
+		"g .. Show debug directories\n"~
 		"d .. Show disassembly (code sections only)"
 //		"D .. Show disassembly (all sections)"
 		;
@@ -382,6 +383,7 @@ int main(int argc, const(char) **argv) {
 				case 'i': opt.flags |= DUMPER_SHOW_IMPORTS; break;
 				case 'c': opt.flags |= DUMPER_SHOW_LOADCFG; break;
 //				case 'e': opt.flags |= DUMPER_SHOW_EXPORTS; break;
+				case 'g': opt.flags |= DUMPER_SHOW_DEBUG; break;
 //				case '': opt.flags |= DUMPER_SHOW_; break;
 				case 'd': opt.flags |= DUMPER_DISASM_CODE; break;
 				case 'D': opt.flags |= DUMPER_DISASM_ALL; break;


### PR DESCRIPTION
adds a "Debug" section to the show the debug directory content with `--show g` flag set like so:

```
*
* Debug
*

Characteristics  00000000
TimeDateStamp    5F1FF581
MajorVersion     00 (0)
MinorVersion     00 (0)
Type             0x02 (CodeView / VC++)
SizeOfData       000000A1 (161)
AddressOfRawData 00866E9C
PointerToRawData 00865A9C

                 PDB 7.0 File (RSDS)
GUID             {2F350D44-2D71-360C-4C4C-44205044422E}
Age              1
Path             C:\Users\jurzitza\Documents\dev\serve-d\.dub\build\executable-debug-windows-x86_64-ldc_2089-76432F28A43D91A92E0699319611B156\serve-d.pdb
```