### PR TITLE
Fix CreateProcessA call

### DIFF
--- a/src/adbg/debugger/debugger.d
+++ b/src/adbg/debugger/debugger.d
@@ -132,7 +132,8 @@ int adbg_load(const(char) *path, const(char) *dir, const(char) **argv, const(cha
 		//
 		STARTUPINFOA si = void;
 		PROCESS_INFORMATION pi = void;
-		memset(&si, 0, si.sizeof + pi.sizeof); // memset faster than _init functions
+		memset(&si, 0, si.sizeof); // memset faster than _init functions
+		memset(&pi, 0, pi.sizeof); // memset faster than _init functions
 		si.cb = STARTUPINFOA.sizeof;
 		// Not using DEBUG_ONLY_THIS_PROCESS because our posix
 		// counterpart is using -1 (all children) for waitpid.


### PR DESCRIPTION
Before it would always crash with error code 87 because the memset would only zero out si and not (fully) pi, probably because of some stack guard.

Is this one-time setup really worth using `= void` and `memset`?