### PR TITLE
Nix Integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ MSG
 # AFL stuff
 /testcases/
 /findings/
+
+# Nix Stuff
+/.direnv/
+/result
+!dub-lock.json
+!dub-lock-docs.json

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Aiming to be a simple cross-platform framework for debugging and object inspecti
 Fully written in D's [BetterC mode](https://dlang.org/spec/betterc.html),
 and available as a DUB package.
 
-It is currently available for Windows, Linux, and FreeBSD.
+It is currently available for Windows, Linux, and FreeBSD, under x86, x86-64, Armv7, and AArch64.
 
 Written from scratch for educational purposes.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,78 @@ for compilation and unittesting.
 Wiki contains more information on structure, features, and compilation
 instructions.
 
+## Nix
+
+this project's flake exposes the following:
+
+(note that all instances of `.#` can be replaced with `github:dd86k/alicedbg#` to do so without needing to have a local copy of the repository)
+
+### DevShell
+
+a devshell providing locked versions of `dub`, `gdc`, `ldc` and `dmd`, along with a nix lsp and formatter can be accessed with:
+
+```
+nix develop .
+```
+
+and will automatically be entered if you have `direnv` configured.
+
+### Packages
+
+packages built with locked versions of dependencies and toolchains are exposed and can be built using a common identifier:
+
+given any combination of:
+
+buildType:
+- debug
+- debugv
+- release
+- release-nobounds
+- docs
+
+config:
+- debugger
+- dumper
+- simple
+- library
+- shared
+
+compiler:
+- ldc
+- dmd
+- gdc
+
+then the appropriate output can be built with:
+
+`nix build .#alicedbg-<buildType>-<config>-<compiler>`
+
+with the results appearing in the `./result`
+
+the default output is `alicedbg-release-debugger-ldc`
+
+### Tests
+
+running `nix flake check` will compile all combinations above with unittests turned on.
+
+`nix flake check .#alicedbg-<buildType>-<config>-<compiler>` will do so for a single output
+
+### Overlay
+
+a nixos overlay is exposed as `.#overlays.default`, which can be used to build all outputs using your own toolchain and versions instead of the ones locked here, all packages are avaliable under `pkgs.alicedbg` with the above names.
+
+### Updating
+
+to update the dependencies nix uses, we must do the following:
+
+```
+dub upgrade --annotate  # generates dub.selections.json
+dub-to-nix > dub-lock.json  # updates lockfile nix uses
+```
+
+also remember to update the `version` attribute on line 19 of `flake.nix` (within the `buildDubPackage` invocation)
+
+the rest of the non-D dependencies can be updated with `nix flake update` which will update the checkout of nixpkgs used by the flake.
+
 # Contributing
 
 Because I'm not very good at managing people and I tend to be a little too

--- a/dub-lock.json
+++ b/dub-lock.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727907660,
+        "narHash": "sha256-QftbyPoieM5M50WKUMzQmWtBWib/ZJbHo7mhj5riQec=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5966581aa04be7eff830b9e1457d56dc70a0b798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,165 @@
+{
+  description = "Alice Debugger Project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    let
+      mkAlicedbg =
+        { buildType
+        , compiler
+        , config
+        }: { buildDubPackage, pkg-config, openssl, ... }:
+        buildDubPackage rec {
+          pname = "alicedbg-${buildType}-${config}-${compiler.pname}";
+          version = "0.4.1";
+          src = ./.;
+          dubLock = ./dub-lock.json;
+          dubBuildType = buildType;
+          dubFlags = [
+            "--config=${config}"
+          ];
+          inherit compiler;
+          buildInputs = [
+            pkg-config
+            openssl
+          ];
+          installPhase =
+            let
+              mvArtifacts = {
+                "debugger" = "install -Dm755 alicedbg -t $out/bin";
+                "dumper" = "install -Dm755 alicedump -t $out/bin";
+                "simple" = "install -Dm755 simple -t $out/bin";
+                "library" = ''
+                  mkdir -p $out/lib
+                  for lib in *.a *.lib; do
+                    if [ -f "$lib" ]; then
+                      install -Dm644 "$lib" "$out/lib"
+                    fi
+                  done
+                '';
+                "shared" = ''
+                  mkdir -p $out/lib
+                  for lib in *.so *.dll; do
+                    if [ -f "$lib" ]; then
+                      install -Dm644 "$lib" "$out/lib"
+                    fi
+                  done
+                '';
+              }.${config};
+            in
+            ''
+              runHook preInstall
+              ${if buildType != "docs"
+                then mvArtifacts
+                else ''
+                  mkdir -p $out
+                  if [ -d docs ]; then
+                    mv docs $out/
+                  fi
+                ''
+              }
+              runHook postInstall
+            '';
+        };
+    in
+    # for a list of avaliable systems
+      # see https://github.com/numtide/flake-utils/blob/main/allSystems.nix
+    flake-utils.lib.eachSystem [
+      "x86_64-windows"
+      "x86_64-linux"
+      "x86_64-freebsd13"
+      "i686-linux"
+      "i686-freebsd13"
+      "i686-windows"
+      "armv7l-linux"
+      "armv7a-linux"
+      "aarch64-linux"
+    ]
+      (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              self.overlays.default
+            ];
+          };
+
+        in
+        {
+          packages = {
+            default = pkgs.alicedbg.alicedbg-release-debugger-ldc;
+          } // pkgs.alicedbg;
+
+          devShells.default = pkgs.mkShell {
+            buildInputs = with pkgs;
+              [
+                nil
+                nixpkgs-fmt
+                dub-to-nix
+                dub
+                dmd
+                ldc
+                gdc
+              ];
+          };
+
+          checks = builtins.mapAttrs
+            (_: p: p.overrideAttrs (oldAttrs: {
+              doCheck = true;
+            }))
+            self.packages.${system};
+        }
+      ) // {
+
+      overlays.default = final: prev:
+        let
+          compilers = [ final.ldc final.dmd final.gdc ];
+          buildTypes = [
+            "debug"
+            "debugv"
+            "release"
+            "release-nobounds"
+            "docs"
+            #"ddox"
+          ];
+          configs = [
+            "debugger"
+            "dumper"
+            "simple"
+            "library"
+            "shared"
+          ];
+          combinations = builtins.concatMap
+            (compiler:
+              builtins.concatMap
+                (buildType:
+                  builtins.map
+                    (config: {
+                      inherit compiler buildType config;
+                    })
+                    configs
+                )
+                buildTypes
+            )
+            compilers;
+          builds = builtins.map
+            (args:
+              final.callPackage (mkAlicedbg args) { })
+            combinations;
+          namedBuilds = builtins.listToAttrs (builtins.map
+            (x: {
+              name = x.pname;
+              value = x;
+            })
+            builds);
+        in
+        {
+          alicedbg = namedBuilds;
+        };
+
+    };
+}

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,11 @@
+# One CLI to format the code tree - https://github.com/numtide/treefmt
+
+[formatter.nix]
+# Formatter to run
+command = "nixpkgs-fmt"
+# Command-line arguments for the command
+options = []
+# Glob pattern of files to include
+includes = [ "*.nix" ]
+# Glob patterns of files to exclude
+excludes = []


### PR DESCRIPTION
Adds a Nix Flake to do the following:

- Build (almost) all combinations of buildTypes / Configs / Compilers
- provide a development environment
- run unit tests for all above packages
- fix versions of the entire toolchain (for both builds and development environments and D dependencies)

also allows integrating into external nix projects, and running / building directly from github without needing to clone the repository

README has been updated with some basic usage

DDox builds are not included currently, because adding Ddox for all builds fails some (some ddox dependencies cannot build with -BetterC), and I havent figured out how to add it as a dependency for only certain build types.

Known bug:
- gdc compiler does not produce docs