### PR TITLE
Easy API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ alicedbg-test-*
 alicedbg-*-test-*
 /alicedump
 alicedump-*-test-*
+/easy-target
+/easy-target.exe
 /simple
 *.dll
 *.dylib

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,135 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Alice Debugger (alicedbg) is a cross-platform debugging and object inspection framework written entirely in D's BetterC mode. It targets Windows, Linux, and FreeBSD on x86, x86-64, Armv7, and AArch64. Pre-1.0 with unstable APIs.
+
+## Build & Test Commands
+
+The project uses DUB (D's package manager/build system). Supported compilers: DMD, LDC, GDC.
+
+```bash
+# Build the library
+dub build
+
+# Build subpackages (executables)
+dub build :debugger    # builds alicedbg CLI
+dub build :dumper      # builds alicedump CLI
+
+# Run tests
+dub test :debugger     # test debugger subpackage
+dub test :dumper       # test dumper subpackage
+
+# Run specific test configurations
+dub test -c threading       # OS threading tests
+dub test -c easy-api        # Easy API integration tests (this needs the easy test target to be built)
+dub test -c setjmp          # setjmp/longjmp tests (unstable on Win64)
+
+# Build types (can be used with subpackages)
+dub build -b debug          # debug mode
+dub build -b release        # release mode
+dub build -b trace          # extremely verbose tracing
+dub build -b release-static # statically linked release
+
+# Generate docs
+dub build -b docs
+```
+
+## Git Branches
+
+- `marisa`: Main development branch (unstable). Use as PR target.
+- `stable`: Last released branch.
+- `easyapi`: Current feature branch for multithreaded Easy API.
+
+## Architecture
+
+Essentially, the Easy API is contained in `easy.d`.
+
+The rest is considered to be Multi API, just like libcurl.
+
+### Library (`src/adbg/`)
+
+The public API surface is defined in `src/adbg/package.d` and re-exports these core modules:
+
+- **`debugger.d`** — Core debugging features: process spawning/attaching, event-driven via ptrace (POSIX) or Windows Debug API
+- **`process/`** — Process management: threads, memory read/write, breakpoints, stack frames, exception info
+- **`objectserver.d`** + **`objects/`** — Binary format parsing for 14+ formats (ELF, PE, Mach-O, PDB, COFF, AR, MZ, NE, LX, etc.)
+- **`disassembler.d`** — Capstone 4.0.2 wrapper for multi-architecture disassembly (optional runtime dependency)
+- **`scanner.d`** — Process memory pattern scanning
+- **`error.d`** — Error handling via `adbg_oops()` (sets global error state, returns error codes)
+- **`easy.d`** — High-level multithreaded debugging loop API using message-based mailboxes (WIP, `easyapi` branch)
+
+### Internal utilities (`src/adbg/utils/`)
+
+- **`bit.d`** — Bit operations.
+- **`date.d`** — Date utilities.
+- **`list.d`** — Provides a simple O(1) list interface to append and retrieve item.
+- **`mailbox.d`** — Multithreading mailbox.
+- **`math.d`** — Math functions.
+- **`strings.d`** — String utilities: arguments, better string length, etc.
+- **`uid.d`** — UUID/GUID utilities.
+
+### OS Abstraction (`src/adbg/os/`)
+
+Threads, mutexes, semaphores, file I/O, path utilities — abstracts platform differences between Windows and POSIX.
+
+### C Bindings (`src/adbg/include/`)
+
+Hand-written bindings organized by platform: `c/` (libc), `windows/`, `posix/`, `linux/`, `freebsd/`, `macos/`, `capstone/`.
+
+### CLI Frontends
+
+- **`debugger/`** — Interactive debugger shell (`shell.d` is the main REPL, ~32KB)
+- **`dumper/`** — Object file dumper with per-format modules (`format_elf.d`, `format_pe.d`, etc.)
+- **`common/`** — Shared CLI utilities (option parsing, terminal ops, error reporting). `sourceLibrary` type, linked into both frontends.
+
+## BetterC Constraints
+
+All code compiles with `-betterC`. This means:
+- No garbage collector, no D runtime exceptions, no `Phobos` standard library
+- No TypeInfo, no ModuleInfo, no classes, no built-in threading (core.thread)
+- No Dynamic arrays (though slices of static arrays and pointers work)
+- No Associative arrays
+- No Exceptions
+- No `synchronized` and core.sync
+- No static module constructors and destructors
+- Manual memory management (`malloc`/`calloc`/`free`)
+- All functions interacting with C use `extern (C)`
+- Error handling is return-code based via `adbg_oops()` in adbg.error
+
+Many D features are retained:
+- unittests, which are written in normal D for convencience.
+- Unrestricted use of compile-time features
+- Full metaprogramming facilities
+- Nested functions, nested structs, delegates and lambdas
+- Member functions, constructors, destructors, operating overloading, etc.
+- The full module system
+- Array slicing, and array bounds checking
+- RAII
+- scope(exit)
+- Memory safety protections
+- Interfacing to C++
+- COM classes and C++ classes
+- assert failures are directed to the C runtime library
+- switch with strings
+- final switch
+- printf format validation
+
+## Code Conventions
+
+- Constants: `UPPER_SNAKE_CASE`
+- Functions: `snake_case` (C-style)
+- Types/structs: `PascalCase`
+- Private members: underscore prefix
+- Platform-specific code uses `version` guards (`version (Windows)`, `version (Posix)`, etc.)
+- Code sections marked with `// ANCHOR Section Name` comments
+- Module headers use triple-slash doc comments with Authors, Copyright, License
+- D-Scanner config in `dscanner.ini` (style checks mostly disabled; code quality checks enabled)
+
+## Optional Dependency
+
+Capstone disassembly engine 4.0.2 is an optional runtime dependency. Install via system package manager (e.g., `libcapstone4` on Debian/Ubuntu 22.04+) or download DLL on Windows.
+
+Assume for it to be installed for development purposes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Alice Debugger (alicedbg) is a cross-platform debugging and object inspection fr
 
 The project uses DUB (D's package manager/build system). Supported compilers: DMD, LDC, GDC.
 
-```bash
+```sh
 # Build the library
 dub build
 
@@ -19,10 +19,11 @@ dub build :debugger    # builds alicedbg CLI
 dub build :dumper      # builds alicedump CLI
 
 # Run tests
-dub test :debugger     # test debugger subpackage
-dub test :dumper       # test dumper subpackage
+dub test               # Run tests for library
+dub test :debugger     # Test debugger subpackage
+dub test :dumper       # Test dumper subpackage
 
-# Run specific test configurations
+# Run specific test configurations (run only if needed/related)
 dub test -c threading       # OS threading tests
 dub test -c easy-api        # Easy API integration tests (this needs the easy test target to be built)
 dub test -c setjmp          # setjmp/longjmp tests (unstable on Win64)
@@ -33,7 +34,7 @@ dub build -b release        # release mode
 dub build -b trace          # extremely verbose tracing
 dub build -b release-static # statically linked release
 
-# Generate docs
+# Generate documentation
 dub build -b docs
 ```
 
@@ -47,7 +48,7 @@ dub build -b docs
 
 Essentially, the Easy API is contained in `easy.d`.
 
-The rest is considered to be Multi API, just like libcurl.
+The rest is considered to be Multi API, akin to libcurl.
 
 ### Library (`src/adbg/`)
 
@@ -121,8 +122,8 @@ Many D features are retained:
 
 - Constants: `UPPER_SNAKE_CASE`
 - Functions: `snake_case` (C-style)
-- Types/structs: `PascalCase`
-- Private members: underscore prefix
+- Enums: `PascalCase`
+- Structs: Typically prefixed with `adbg_` and suffixed with `_t`
 - Platform-specific code uses `version` guards (`version (Windows)`, `version (Posix)`, etc.)
 - Code sections marked with `// ANCHOR Section Name` comments
 - Module headers use triple-slash doc comments with Authors, Copyright, License
@@ -133,3 +134,9 @@ Many D features are retained:
 Capstone disassembly engine 4.0.2 is an optional runtime dependency. Install via system package manager (e.g., `libcapstone4` on Debian/Ubuntu 22.04+) or download DLL on Windows.
 
 Assume for it to be installed for development purposes.
+
+## Important Notes
+
+### Windows
+
+The Debugger API on Windows require all calls to be done by the thread that initially spawned or attached to the process.

--- a/common/src/cli.d
+++ b/common/src/cli.d
@@ -164,6 +164,9 @@ int cli_build_info() {
 	"Config     "~D_FEATURES;
 	puts(page);
 	
+	import adbg.os.threads : os_thread_model;
+	printf("Thread      %s\n", os_thread_model());
+	
 	static if (GDC_VERSION) {
 		printf("GCC         %d\n", GDC_VERSION);
 		printf("GDC-EH      %s\n", GDC_EXCEPTION_MODE);

--- a/common/src/errormgmt.d
+++ b/common/src/errormgmt.d
@@ -16,22 +16,20 @@ import core.stdc.string : strerror;
 import core.stdc.errno : errno;
 import core.stdc.stdio;
 import core.stdc.stdlib : exit;
+import common.terminal;
 
 extern (C):
 
 void print_error(const(char) *message, int code,
 	const(char)* prefix = null, const(char)* mod = cast(char*)__MODULE__, int line = __LINE__) {
-	debug fprintf(stderr, "[%s@%d] ", mod, line);
-	fputs("error: ", stderr);
-	if (prefix) {
-		fputs(prefix, stderr);
-		fputs(": ", stderr);
-	}
-	fprintf(stderr, "(%d) %s\n", code, message);
+	debug console_writef(CONSOLE_STDERR, "[%s@%d] ", mod, line);
+	console_write2(CONSOLE_STDERR, "error: ");
+	if (prefix)
+		console_writef(CONSOLE_STDERR, "%s: ", prefix);
+	console_writef(CONSOLE_STDERR, "(%d) %s\n", code, message);
 }
 void print_error_adbg(
 	const(char)* mod = __FILE__.ptr, int line = __LINE__) {
-	debug fprintf(stderr, "[%s@%d] ", mod, line);
 	print_error(adbg_error_message(), adbg_error_code(), null, adbg_error_function(), adbg_error_line());
 }
 
@@ -57,7 +55,7 @@ int errorcode() {
 }
 
 void crashed(adbg_process_t *proc, adbg_exception_t *ex) {
-	fputs(
+	console_write2(CONSOLE_STDERR,
 `
    _ _ _   _ _ _       _ _       _ _ _   _     _   _
  _|_|_|_| |_|_|_|_   _|_|_|_   _|_|_|_| |_|   |_| |_|
@@ -65,20 +63,19 @@ void crashed(adbg_process_t *proc, adbg_exception_t *ex) {
 |_|       |_|_|_|_  |_|_|_|_|   |_|_|_  |_|_|_|_| |_|
 |_|_ _ _  |_|   |_| |_|   |_|  _ _ _|_| |_|   |_|  _
   |_|_|_| |_|   |_| |_|   |_| |_|_|_|   |_|   |_| |_|
-`,
-	stderr);
+`);
 	
 	// NOTE: Any future call could make the app crash harder,
 	//       so, print one line at at time
-	fprintf(stderr, "PID        : %d\n", adbg_process_id(proc));
-	fprintf(stderr, "Code       : "~ERR_OSFMT~"\n", ex.oscode);
-	fprintf(stderr, "Exception  : %s\n", adbg_exception_name(ex));
+	console_writef(CONSOLE_STDERR, "PID        : %d\n", adbg_process_id(proc));
+	console_writef(CONSOLE_STDERR, "Code       : "~ERR_OSFMT~"\n", ex.oscode);
+	console_writef(CONSOLE_STDERR, "Exception  : %s\n", adbg_exception_name(ex));
 	
 	// TODO: Get thread context
 	
 	// Fault address & disasm if available
 	if (ex.fault_address) {
-		fprintf(stderr, "Address    : %#llx\n", ex.fault_address);
+		console_writef(CONSOLE_STDERR, "Address    : %#llx\n", ex.fault_address);
 		
 		ubyte[OPCODE_BUFSIZE] buffer = void;
 		adbg_opcode_t op = void;
@@ -90,17 +87,17 @@ void crashed(adbg_process_t *proc, adbg_exception_t *ex) {
 		if (adbg_disassemble(dis, &op, buffer.ptr, OPCODE_BUFSIZE))
 			goto Lunavail;
 		
-		fprintf(stderr, "Instruction:");
+		console_write2(CONSOLE_STDERR, "Instruction:");
 		for (size_t bi; bi < op.size; ++bi)
-			fprintf(stderr, " %02x", op.data[bi]);
-		fprintf(stderr, " (%s", op.mnemonic);
-		if (op.operands) fprintf(stderr, " %s", op.operands);
-		fputs(")", stderr);
+			console_writef(CONSOLE_STDERR, " %02x", op.data[bi]);
+		console_writef(CONSOLE_STDERR, " (%s", op.mnemonic);
+		if (op.operands) console_writef(CONSOLE_STDERR, " %s", op.operands);
+		console_write2(CONSOLE_STDERR, ")");
 		
 		goto Lcont;
 		
 	Lunavail:
-		fprintf(stderr, " Disassembly unavailable (%s)\n", adbg_error_message());
+		console_writef(CONSOLE_STDERR, " Disassembly unavailable (%s)\n", adbg_error_message());
 	Lcont:
 	}
 	

--- a/common/src/terminal.d
+++ b/common/src/terminal.d
@@ -139,6 +139,15 @@ ushort console_fgcolor_win(TextColor color) {
 	}
 }
 
+version (Posix)
+private
+string console_fgcolor_xterm(TextColor color) {
+	final switch (color) {
+	case TextColor.red   : return "\033[31m";
+	case TextColor.yellow: return "\033[33m";
+	}
+}
+
 version (Windows)
 private
 HANDLE console_handle(int stream) {
@@ -151,10 +160,11 @@ HANDLE console_handle(int stream) {
 
 version (Posix)
 private
-string console_fgcolor_xterm(TextColor color) {
-	final switch (color) {
-	case TextColor.red   : return "\033[31m";
-	case TextColor.yellow: return "\033[33m";
+int console_handle(int stream) {
+	final switch (stream) {
+	case CONSOLE_STDIN:  return STDIN_FILENO;
+	case CONSOLE_STDOUT: return STDOUT_FILENO;
+	case CONSOLE_STDERR: return STDERR_FILENO;
 	}
 }
 
@@ -164,8 +174,8 @@ version (Windows) {
 		console_handle(stream),
 		(defaultColor & 0xfff0) | console_fgcolor_win(color));
 } else version (Posix) {
-	string color = console_fgcolor_xterm(color);
-	write(console_handle(stream), color.ptr, color.length);
+	string s = console_fgcolor_xterm(color);
+	write(console_handle(stream), s.ptr, s.length);
 }
 }
 

--- a/common/src/terminal.d
+++ b/common/src/terminal.d
@@ -3,7 +3,7 @@
 /// Authors: dd86k <dd@dax.moe>
 /// Copyright: © dd86k <dd@dax.moe>
 /// License: BSD-3-Clause-Clear
-module term;
+module common.terminal;
 
 import core.stdc.stdlib;
 import adbg.include.c.stdio;
@@ -29,9 +29,9 @@ version (Windows) {
 	private import core.sys.posix.ucontext;
 	
 	version (CRuntime_Musl) {
-		alias uint tcflag_t;
-		alias uint speed_t;
-		alias char cc_t;
+		alias tcflag_t = uint;
+		alias speed_t = uint;
+		alias cc_t = char;
 		private enum TCSANOW	= 0;
 		private enum NCCS	= 32;
 		private enum ICANON	= 2;
@@ -67,7 +67,11 @@ version (Windows) {
 	private __gshared termios old_tio = void, new_tio = void;
 }
 
-// Flags: CONFxyz
+enum { // older compilers fuck up standard C stream definitions
+	CONSOLE_STDIN  = 0,
+	CONSOLE_STDOUT = 1,
+	CONSOLE_STDERR = 2,
+}
 
 private __gshared {
 	/// User defined function for resize events
@@ -81,13 +85,13 @@ private __gshared {
 
 /// Initiates terminal basics
 /// Returns: Error keyCode, non-zero on error
-int coninit(/*int flags = 0*/) {
+int console_init() {
 version (Posix) {
 	tcgetattr(STDIN_FILENO, &old_tio);
 	new_tio = old_tio;
 	new_tio.c_lflag &= TERM_ATTR;
 
-	//TODO: See flags we can put
+	// TODO: See flags we can put
 	// tty_ioctl TIOCSETD
 } else {
 	handleOut = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -127,7 +131,8 @@ enum TextColor {
 // https://ss64.com/nt/color.html
 
 version (Windows)
-ushort concolor(TextColor color) {
+private
+ushort console_fgcolor_win(TextColor color) {
 	final switch (color) {
 	case TextColor.red:    return FOREGROUND_RED;
 	case TextColor.yellow: return FOREGROUND_GREEN | FOREGROUND_RED;
@@ -135,73 +140,75 @@ ushort concolor(TextColor color) {
 }
 
 version (Windows)
-HANDLE conhandle(FILE *stream) {
-	if (stream == stdout)
-		return handleOut;
-	else if (stream == stderr)
-		return handleErr;
-	assert(false, "no stream map");
+private
+HANDLE console_handle(int stream) {
+	final switch (stream) {
+	case CONSOLE_STDIN:  return handleIn;
+	case CONSOLE_STDOUT: return handleOut;
+	case CONSOLE_STDERR: return handleErr;
+	}
 }
 
 version (Posix)
-const(char)* concolor(TextColor color) {
+private
+string console_fgcolor_xterm(TextColor color) {
 	final switch (color) {
 	case TextColor.red   : return "\033[31m";
 	case TextColor.yellow: return "\033[33m";
 	}
 }
 
-// Set foreground text color for stdout
-void concoltext(TextColor color, FILE *stream = stdout) {
+void console_fgcolor(TextColor color, int stream) {
 version (Windows) {
-	ushort c = concolor(color);
-	HANDLE h = conhandle(stream);
-	SetConsoleTextAttribute(h, (defaultColor & 0xfff0) | c);
-}
-version (Posix) {
-	const(char) *c = concolor(color);
-	fputs(c, stream);
+	SetConsoleTextAttribute(
+		console_handle(stream),
+		(defaultColor & 0xfff0) | console_fgcolor_win(color));
+} else version (Posix) {
+	string color = console_fgcolor_xterm(color);
+	write(console_handle(stream), color.ptr, color.length);
 }
 }
 
 // Invert console color with default color
-void concolinv(FILE *stream = stdout) {
+void console_invert(int stream) {
 version (Windows) {
-	HANDLE h = conhandle(stream);
-	SetConsoleTextAttribute(h, COMMON_LVB_REVERSE_VIDEO | defaultColor);
+	SetConsoleTextAttribute(console_handle(stream), COMMON_LVB_REVERSE_VIDEO | defaultColor);
+} else version (Posix) {
+	static immutable string c = "\033[7m";
+	write(console_handle(stream), c.ptr, c.length);
 }
-version (Posix)
-	fputs("\033[7m", stream);
 }
 
 // Reset console color to default color
-void concolrst(FILE *stream = stdout) {
+void console_reset(int stream) {
 version (Windows) {
-	HANDLE h = conhandle(stream);
-	SetConsoleTextAttribute(h, defaultColor);
+	SetConsoleTextAttribute(console_handle(stream), defaultColor);
+} else version (Posix) {
+	static immutable string c = "\033[0m";
+	write(console_handle(stream), c.ptr, c.length);
 }
-version (Posix)
-	fputs("\033[0m", stream);
 }
 
 /// Clear screen
-void conclear() {
+void console_clear(int stream = CONSOLE_STDOUT) {
 version (Windows) {
+	HANDLE h = console_handle(stream);
 	CONSOLE_SCREEN_BUFFER_INFO csbi = void;
 	COORD c; // 0, 0
-	GetConsoleScreenBufferInfo(handleOut, &csbi);
-	//const int buflen = csbi.dwSize.X * csbi.dwSize.Y; buf buflen
+	GetConsoleScreenBufferInfo(h, &csbi);
 	const int buflen = // window buflen
 		(csbi.srWindow.Right - csbi.srWindow.Left + 1)* // width
 		(csbi.srWindow.Bottom - csbi.srWindow.Top + 1); // height
 	DWORD num = void; // kind of ala .NET
-	FillConsoleOutputCharacterA(handleOut, ' ', buflen, c, &num);
-	FillConsoleOutputAttribute(handleOut, csbi.wAttributes, buflen, c, &num);
-	conmvcur(0, 0);
+	FillConsoleOutputCharacterA(h, ' ', buflen, c, &num);
+	FillConsoleOutputAttribute(h, csbi.wAttributes, buflen, c, &num);
+	console_seek(0, 0);
 } else version (Posix) {
+	int fd = console_handle(stream);
 	// "ESC [ 2 J" acts like clear(1)
 	// "ESC c" is a full reset ala cls (Windows)
-	printf("\033c");
+	static immutable string c = "\033c";
+	write(fd, c.ptr, c.length);
 }
 else static assert(false, "Not implemented");
 }
@@ -210,18 +217,18 @@ else static assert(false, "Not implemented");
 /// Params:
 ///   w = Width (columns) pointer.
 ///   h = Height (rows) pointer.
-void consize(int *w, int *h) {
+void console_size(int *w, int *h) {
 	/// NOTE: A COORD uses SHORT (short) and Linux uses unsigned shorts.
 version (Windows) {
 	CONSOLE_SCREEN_BUFFER_INFO c = void;
 	GetConsoleScreenBufferInfo(handleOut, &c);
-	*w = c.srWindow.Right - c.srWindow.Left + 1;
-	*h = c.srWindow.Bottom - c.srWindow.Top + 1;
+	if (w) *w = c.srWindow.Right - c.srWindow.Left + 1;
+	if (h) *h = c.srWindow.Bottom - c.srWindow.Top + 1;
 } else version (Posix) {
 	winsize win = void;
 	ioctl(STDOUT_FILENO, TIOCGWINSZ, &win);
-	*w = win.ws_col;
-	*h = win.ws_row;
+	if (w) *w = win.ws_col;
+	if (h) *h = win.ws_row;
 }
 }
 
@@ -231,7 +238,7 @@ version (Windows) {
 /// Params:
 ///   x = X position (horizontal, columns)
 ///   y = Y position (vertical, rows)
-void conmvcur(int x, int y) {
+void console_seek(int x, int y) {
 version (Windows) { // 0-based
 	COORD c = { cast(SHORT)x, cast(SHORT)y };
 	SetConsoleCursorPosition(handleOut, c);
@@ -246,7 +253,9 @@ version (Windows) { // 0-based
 /// Params:
 ///   x = X position (horizontal, columns)
 ///   y = Y position (vertical, rows)
-void congetxy(int *x, int *y) {
+void console_tell(int *x, int *y) {
+	assert(x);
+	assert(y);
 version (Windows) { // 0-based
 	CONSOLE_SCREEN_BUFFER_INFO csbi = void;
 	GetConsoleScreenBufferInfo(handleOut, &csbi);
@@ -262,6 +271,42 @@ version (Windows) { // 0-based
 }
 }
 
+import adbg.include.c.stdarg;
+
+size_t console_writef(int stream, const(char) *fmt, ...) {
+	va_list args = void;
+	va_start(args, fmt);
+	return console_vwritef(stream, fmt, args);
+}
+
+
+size_t console_vwritef(int stream, const(char) *fmt, va_list args) {
+	enum len = 512;
+	char[len] buf = void;
+	int r = vsnprintf(buf.ptr, len, fmt, args);
+	buf[r++] = '\n';
+	return console_write(stream, buf.ptr, r);
+}
+
+size_t console_write2(int stream, const(char)[] data) {
+	return console_write(stream, data.ptr, data.length);
+}
+
+size_t console_write(int stream, const(char) *data, size_t size) {
+version (Windows) {
+	uint r = void;
+	if (WriteFile(console_handle(stream), data, cast(uint)size, &r, null) == FALSE)
+		return 0;
+	return r;
+} else version (Posix) {
+	ssize_t r = write(console_handle(stream), data, size);
+	if (r < 0)
+		return 0;
+	// TODO: flush (due to fbcon)
+	return r;
+}
+}
+
 //
 // ANCHOR Terminal input
 //
@@ -272,7 +317,7 @@ version (Windows) { // 0-based
 /// Windows: User handler function called if EventType is WINDOW_BUFFER_SIZE_EVENT.
 /// Posix: Handled externally via the SIGWINCH signal.
 /// Params: ii = InputInfo structure
-void conrdkey(InputInfo *ii) {
+void console_readkey(InputInfo *ii) {
 	ii.type = InputType.None;
 version (Windows) {
 	INPUT_RECORD ir = void;
@@ -382,7 +427,7 @@ L_DEFAULT:
 
 /// Read a line from stdin.
 /// Returns: Character slice; Or null on error.
-char[] conrdln() {
+char[] console_readline() {
 	import core.stdc.ctype : isprint;
 	
 	enum BUFFERSIZE = 512; // GNU readline has this set to 512

--- a/debugger/src/main.d
+++ b/debugger/src/main.d
@@ -9,7 +9,8 @@ import adbg.self;
 import adbg.error;
 import core.stdc.stdlib : strtol, EXIT_SUCCESS, EXIT_FAILURE, exit;
 import core.stdc.stdio;
-import shell, term;
+import shell;
+import common.terminal;
 import common.errormgmt;
 import common.cli;
 import common.utils;
@@ -81,7 +82,8 @@ int cli_help() {
 	getoptprinter(options[NUMBER_OF_SECRETS..$]);
 	puts("\nFor a list of values, for example a list of platforms, type '-a help'");
 	exit(0);
-	return 0;
+	// noreturn exit
+	static if (__VERSION__ > 2099) return 0;
 }
 
 // --meow: Secret
@@ -99,7 +101,8 @@ int cli_meow() {
 `
 	);
 	exit(0);
-	return 0;
+	// noreturn exit
+	static if (__VERSION__ > 2099) return 0;
 }
 
 extern (C)
@@ -108,7 +111,7 @@ int main(int argc, const(char)** argv) {
 	// Could do a warning, but it might be a little confusing
 	adbg_self_set_crashhandler(&crashed);
 	
-	coninit();
+	console_init(); // for logerror
 	
 	argc = getoptions(argc, argv, options);
 	if (argc < 0) {

--- a/debugger/src/shell.d
+++ b/debugger/src/shell.d
@@ -17,7 +17,7 @@ import core.stdc.string;
 import common.errormgmt;
 import common.cli : opt_syntax;
 import common.utils;
-import term;
+import common.terminal;
 
 extern (C):
 
@@ -119,28 +119,32 @@ void loginfo(const(char) *fmt, ...) {
 	logwrite(null, 0, fmt, args);
 }
 private
-void logwrite(const(char) *pre, int color, const(char) *fmt, va_list args) {
+void logwrite(string pre, int color, const(char) *fmt, va_list args) {
 	if (pre) {
 		if ((shellflags & SHELL_NOCOLORS) == 0)
-			concoltext(cast(TextColor)color, stderr);
-		fputs(pre, stderr);
+			console_fgcolor(cast(TextColor)color, CONSOLE_STDERR);
+		console_write(CONSOLE_STDERR, pre.ptr, pre.length);
 		if ((shellflags & SHELL_NOCOLORS) == 0)
-			concolrst(stderr);
-		fputs(": ", stderr);
+			console_reset(CONSOLE_STDERR);
+		console_write2(CONSOLE_STDERR, ": ");
 	}
 	
-	vfprintf(stderr, fmt, args);
-	putchar('\n');
+	/*enum len = 512;
+	char[len] buf = void;
+	int r = vsnprintf(buf.ptr, len, fmt, args);
+	buf[r++] = '\n';
+	console_write(CONSOLE_STDERR, buf.ptr, r);*/
+	console_vwritef(CONSOLE_STDERR, fmt, args);
 }
 
 int shell_start(int argc, const(char)** argv) {
 Lcommand:
-	fputs("(adbg) ", stdout);
-	fflush(stdout);
+	/// stdout/stderr leads to windows linker errors for dmd <=2.099
+	console_write2(CONSOLE_STDOUT, "(adbg) ");
 	
 	// .ptr is temporary because a slice with a length of 0
 	// also make its pointer null.
-	char* line = conrdln().ptr;
+	char* line = console_readline().ptr;
 	
 	// Invalid line or CTRL+D
 	if (line == null || line[0] == 4)
@@ -567,11 +571,6 @@ immutable(command2_t)* shell_findcommand(const(char) *ucommand) {
 
 // After 
 int shell_setup() {
-	if (adbg_debugger_on_exception(process, &shell_event_exception) ||
-		adbg_debugger_on_process_exit(process, &shell_event_process_exit) ||
-		adbg_debugger_on_process_continue(process, &shell_event_process_continue))
-		return ShellError.alicedbg;
-	
 	// Open disassembler for process machine type
 	disassembler = adbg_disassembler_open(adbg_process_machine(process));
 	if (disassembler == null) {
@@ -585,6 +584,37 @@ int shell_setup() {
 	}
 	
 	return 0;
+}
+
+void shell_print_event(adbg_event_t *event, adbg_process_t *process) {
+	switch (event.type) {
+	case AdbgEvent.exception:
+		adbg_exception_t *exception = &event.exception;
+		
+		int pid = adbg_process_id(process);
+		adbg_process_thread_t *thread = adbg_exception_thread(exception);
+		event_tid = adbg_process_thread_id(thread);
+		
+		printf("[adbg] Process %d (thread %lld) stopped\n"~
+			"[adbg] Reason  : %s ("~ERR_OSFMT~")\n",
+			pid, event_tid,
+			adbg_exception_name(exception), adbg_exception_orig_code(exception));
+		
+		// Fault address available, print it
+		ulong faddr = adbg_exception_fault_address(exception);
+		shell_print_address_disasm(faddr);
+		
+		shell_print_stack(thread);
+		break;
+	case AdbgEvent.processExit:
+		printf("[adbg] Process %d exited with code %d\n", adbg_process_id(process), event.exitcode);
+		break;
+	case AdbgEvent.processContinue:
+		printf("[adbg] Process %d continued\n", adbg_process_id(process));
+		break;
+	default:
+		
+	}
 }
 
 // TODO: Move as common.disassembler module
@@ -813,14 +843,6 @@ int command_restart(int argc, const(char) **argv) {
 	}
 }
 
-int command_go(int argc, const(char) **argv) {
-	if (event_tid && adbg_debugger_continue(process, event_tid))
-		return ShellError.alicedbg;
-	if (adbg_debugger_wait(process))
-		return ShellError.alicedbg;
-	return 0;
-}
-
 int command_kill(int argc, const(char) **argv) {
 	if (adbg_debugger_terminate(process))
 		return ShellError.alicedbg;
@@ -829,12 +851,26 @@ int command_kill(int argc, const(char) **argv) {
 	return 0;
 }
 
+int command_go(int argc, const(char) **argv) {
+	if (event_tid && adbg_debugger_continue(process, event_tid))
+		return ShellError.alicedbg;
+	adbg_event_t event = void;
+	adbg_process_t *proc = adbg_debugger_wait(process, &event);
+	if (proc == null)
+		return ShellError.alicedbg;
+	shell_print_event(&event, proc);
+	return 0;
+}
+
 // NOTE: Can't simply execute stepi multiple times in a row
 int command_stepi(int argc, const(char) **argv) {
 	if (adbg_debugger_step_instruction(process, event_tid))
 		return ShellError.alicedbg;
-	if (adbg_debugger_wait(process))
+	adbg_event_t event = void;
+	adbg_process_t *proc = adbg_debugger_wait(process, &event);
+	if (proc == null)
 		return ShellError.alicedbg;
+	shell_print_event(&event, proc);
 	return 0;
 }
 
@@ -1242,7 +1278,6 @@ int command_quit(int argc, const(char) **argv) {
 	if (process) {
 		printf("Process %d is still running. Quit and terminate? [Y/n] ",
 			adbg_process_id(process));
-		fflush(stdout);
 	Lgetchar:
 		int c = getchar();
 		switch (c) {

--- a/debugger/src/shell.d
+++ b/debugger/src/shell.d
@@ -35,7 +35,7 @@ enum ShellError {
 	none	= 0,
 	invalidParameter	= -1,
 	invalidCommand	= -2, // or action or sub-command
-	unavailable	= -3,
+	unavailable	= -3, // Feature unavailable
 	loadFailed	= -4,
 	pauseRequired	= -5,
 	alreadyLoaded	= -6,
@@ -53,6 +53,8 @@ enum ShellError {
 	
 	crt	= -1000,
 	alicedbg	= -1001,
+	
+	assertion	= -9999,
 }
 
 const(char) *shell_error_string(int code) {
@@ -754,6 +756,17 @@ void shell_event_help(immutable(command2_t) *command) {
 	putchar('\n');
 }
 
+const(char)* shell_process_status(){
+	if (process == null || adbg_process_is_attached(process) == 0)
+		return "unattached";
+	else if (adbg_process_is_alive(process) == 0)
+		return "exited";
+	else if (adbg_process_is_stopped(process))
+		return "stopped";
+	else
+		return "unknown";
+}
+
 debug // This is only to test the crash handler
 int command_crash(int, const(char) **) {
 	void function() fnull;
@@ -762,7 +775,7 @@ int command_crash(int, const(char) **) {
 }
 
 int command_status(int argc, const(char) **argv) {
-	puts(adbg_process_status_string(process));
+	puts(shell_process_status());
 	return 0;
 }
 
@@ -820,22 +833,23 @@ int command_detach(int argc, const(char) **argv) {
 }
 
 int command_restart(int argc, const(char) **argv) {
-	switch (process.creation) with (AdbgCreation) {
-	case spawned:
+	// Hack to restart debugging session
+	
+	if (process && last_spawn_exec) {
 		// Terminate first, ignore on error (e.g., already gone)
 		adbg_debugger_terminate(process);
 		
-		// Spawn, shell still messages status
 		return shell_spawn(last_spawn_exec, last_spawn_argv);
-	case attached:
+	} else if (last_spawn_exec) {
+		return shell_spawn(last_spawn_exec, last_spawn_argv);
+	} else if (process) {
 		// Detach first, ignore on error (e.g., already detached)
 		adbg_debugger_detach(process);
 		
 		// Attach, shell still messages status
 		return shell_attach(opt_pid);
-	default:
-		return ShellError.unattached;
-	}
+	} else
+		return ShellError.assertion; // no idea
 }
 
 int command_kill(int argc, const(char) **argv) {

--- a/debugger/src/shell.d
+++ b/debugger/src/shell.d
@@ -129,11 +129,6 @@ void logwrite(string pre, int color, const(char) *fmt, va_list args) {
 		console_write2(CONSOLE_STDERR, ": ");
 	}
 	
-	/*enum len = 512;
-	char[len] buf = void;
-	int r = vsnprintf(buf.ptr, len, fmt, args);
-	buf[r++] = '\n';
-	console_write(CONSOLE_STDERR, buf.ptr, r);*/
 	console_vwritef(CONSOLE_STDERR, fmt, args);
 }
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -93,6 +93,15 @@ buildType "debugv" {
 	dflags "-ftransition=nogc" "-ftransition=tls" platform="gdc"
 }
 
+# Make the compiler print GC and TLS usage, and target information for unittests.
+buildType "debugvt" {
+	versions "DebugV" "PrintTargetInfo"
+	buildOptions "debugMode" "debugInfo" "unittests"
+	dflags "-vgc" "-vtls" platform="dmd"
+	dflags "--vgc" platform="ldc"
+	dflags "-ftransition=tls" platform="gdc"
+}
+
 # Ditto but aimed for older compiler version
 # Like older dmd versions, ldc 0.17.1, and gdc 6.0
 buildType "debugv0" {

--- a/dub.sdl
+++ b/dub.sdl
@@ -178,9 +178,9 @@ configuration "readln" {
 	sourceFiles "tests/readln.d" "debugger/src/term.d"
 }
 # Too OS-specific to be a regular unittest
-#configuration "threading" {
-#	sourceFiles "tests/threading.d"
-#}
+configuration "threading" {
+	sourceFiles "tests/threading.d"
+}
 
 #
 # ANCHOR Documentation build types (docs/ddox)

--- a/dub.sdl
+++ b/dub.sdl
@@ -181,6 +181,10 @@ configuration "readln" {
 configuration "threading" {
 	sourceFiles "tests/threading.d"
 }
+# Integration test
+configuration "easy-api" {
+	sourceFiles "tests/easy.d"
+}
 
 #
 # ANCHOR Documentation build types (docs/ddox)

--- a/dumper/src/main.d
+++ b/dumper/src/main.d
@@ -15,6 +15,7 @@ import adbg.error;
 import core.stdc.stdlib : EXIT_FAILURE;
 import core.stdc.stdio;
 import dumper;
+import common.terminal;
 import common.errormgmt;
 import common.cli;
 import common.utils;
@@ -223,6 +224,8 @@ int main(int argc, const(char)** argv) {
 		puts("error: No file specified");
 		return EXIT_FAILURE;
 	}
+	
+	console_init();
 	
 	return dump_file(*getoptleftovers()); // First argument as file
 }

--- a/src/adbg/debugger.d
+++ b/src/adbg/debugger.d
@@ -303,8 +303,7 @@ version (Windows) {
 	process.orig_handle = pi.hProcess;
 	process.orig_pid = process.pid = pi.dwProcessId;
 	
-	process.state = AdbgProcessState.created;
-	process.creation = AdbgCreation.spawned;
+	process.status = ADBG_PROCESS_ATTACHED;
 	process.option_timeout = INFINITE;
 	return process;
 } else version (Posix) {
@@ -665,11 +664,13 @@ version (Windows) {
 	DEBUG_EVENT de = void;
 Lwait:
 	if (WaitForDebugEvent(&de, process.option_timeout) == FALSE) {
-		process.state = AdbgProcessState.unknown;
 		return null;
 	}
 	
+	process.status |= ADBG_PROCESS_STOPPED;
+	
 	event.process.pid = de.dwProcessId;
+	event.process.status = process.status;
 	event.process.option_timeout = process.option_timeout;
 	
 	// Filter events
@@ -914,7 +915,6 @@ version (Windows) {
 	// HACK: Created processes are not in a "stopped" state
 	//       But will continue at the next wait call
 	if (ContinueDebugEvent(process.pid, cast(DWORD)tid, DBG_CONTINUE) == FALSE) {
-		process.state = AdbgProcessState.unknown;
 		return adbg_oops(AdbgError.os);
 	}
 } else version (linux) {

--- a/src/adbg/debugger.d
+++ b/src/adbg/debugger.d
@@ -648,7 +648,7 @@ version (Windows) {
 ///
 /// Params: process = Process instance created by debugger.
 /// Returns: Affected process instance by debugging event. Or null on error.
-adbg_process_t* adbg_debugger_wait(scope adbg_process_t *process, scope adbg_event_t *event) {
+adbg_process_t* adbg_debugger_wait(adbg_process_t *process, adbg_event_t *event) {
 	version(Trace) trace("process=%p", process);
 	
 	if (process == null || event == null) {

--- a/src/adbg/debugger.d
+++ b/src/adbg/debugger.d
@@ -27,6 +27,7 @@ version (Windows) {
 	import core.sys.windows.winbase;
 	import adbg.include.windows.wow64apiset;
 	import adbg.include.windows.winnt;
+	import adbg.include.windows.ntdll;
 	import adbg.machines;
 	
 	version (X86)	version = WinTel;
@@ -39,6 +40,7 @@ version (Windows) {
 	import adbg.include.posix.ptrace;
 	import adbg.include.posix.unistd;
 	import adbg.include.posix.sys.wait;
+	import adbg.include.posix.signal;
 	import core.stdc.errno;
 	import core.sys.posix.fcntl;
 	
@@ -67,6 +69,8 @@ enum AdbgEvent {
 	processExit,
 	/// A process continued.
 	processContinue,
+	/// A process was paused or suspended.
+	processPaused,
 }
 
 /// Represents a debugger event.
@@ -691,8 +695,16 @@ Lwait:
 		event.exception.thread.id      = de.dwThreadId;
 		event.exception.thread.process = process;
 		event.exception.thread.status  = 0;
+
+		// Detect DebugBreakProcess: EXCEPTION_BREAKPOINT with PAUSED flag set
+		if (de.Exception.ExceptionRecord.ExceptionCode == STATUS_BREAKPOINT
+				&& (process.status & ADBG_PROCESS_PAUSED)) {
+			event.type = AdbgEvent.processPaused;
+			process.status &= ~ADBG_PROCESS_PAUSED; // no longer paused if something happens
+		}
+
 		return &event.process;
-		
+
 		//goto Lcontinue; // auto-continue
 	case EXIT_PROCESS_DEBUG_EVENT:
 		version(Trace) trace("ProcExit pid=%d tid=%d code=%u",
@@ -758,22 +770,29 @@ Lwait:
 			process.event_process_continued(process, udata);*/
 	} else if (WIFSTOPPED(wstatus)) { // stopped by signal
 		version (Trace) trace("Stopped status=%#x pid=%d", wstatus, process.pid);
-		
-		event.type = AdbgEvent.exception;
-		
+
 		process.status |= ADBG_PROCESS_STOPPED;
 		event.process.status = process.status;
-		
+
 		int signo = WSTOPSIG(wstatus);
-		
+
+		// Detect pause/suspend: SIGSTOP with PAUSED flag set
+		if (signo == SIGSTOP && (process.status & (ADBG_PROCESS_PAUSED | ADBG_PROCESS_SUSPENDED))) {
+			event.type = AdbgEvent.processPaused;
+			process.status &= ~ADBG_PROCESS_PAUSED; // no longer paused
+			return &event.process;
+		}
+
+		event.type = AdbgEvent.exception;
+
 		adbg_translate_exception(&event.exception, &event.process, cast(void*)signo);
-		
+
 		// HACK: fill up thread details for exception
 		event.exception.thread.process = &event.process;
 		event.exception.thread.id      = event.process.pid;
 		event.exception.thread.status  = 0;
 		return &event.process;
-		
+
 		//int e = adbg_debugger_continue(process, process.pid);
 		//if (e) return null;
 		//goto Lwait;
@@ -949,6 +968,114 @@ version (Windows) {
 } else static assert(0, "Implement adbg_debugger_continue");
 	
 	process.status &= ~ADBG_PROCESS_STOPPED;
+	return 0;
+}
+
+/// Debug break: interrupt the process and generate a debug event.
+///
+/// The event loop will report a `processPaused` event.
+/// Call `adbg_debugger_continue` to resume after a debug break.
+/// Windows: Uses DebugBreakProcess which injects a breakpoint exception.
+/// POSIX: Sends SIGSTOP which is intercepted by ptrace.
+/// Params: process = Process instance.
+/// Returns: Error code.
+int adbg_debugger_pause(adbg_process_t *process) {
+	if (process == null)
+		return adbg_oops(AdbgError.invalidArgument);
+	if ((process.status & ADBG_PROCESS_ATTACHED) == 0)
+		return adbg_oops(AdbgError.debuggerUnattached);
+	if (process.status & (ADBG_PROCESS_PAUSED | ADBG_PROCESS_SUSPENDED))
+		return adbg_oops(AdbgError.debuggerInvalidAction);
+
+	process.status |= ADBG_PROCESS_PAUSED; // set before so wait catches it
+
+version (Windows) {
+	HANDLE phandle = OpenProcess(PROCESS_CREATE_THREAD, FALSE, cast(DWORD)process.pid);
+	if (phandle == null) {
+		process.status &= ~ADBG_PROCESS_PAUSED;
+		return adbg_oops(AdbgError.os);
+	}
+	scope(exit) CloseHandle(phandle);
+	if (DebugBreakProcess(phandle) == FALSE) {
+		process.status &= ~ADBG_PROCESS_PAUSED;
+		return adbg_oops(AdbgError.os);
+	}
+} else version (Posix) {
+	if (kill(process.pid, SIGSTOP) < 0) {
+		process.status &= ~ADBG_PROCESS_PAUSED;
+		return adbg_oops(AdbgError.os);
+	}
+}
+	return 0;
+}
+
+/// Suspend the process at OS level.
+///
+/// On Windows, uses NtSuspendProcess. This does NOT generate a debug event.
+/// On POSIX, sends SIGSTOP (same as pause; ptrace intercepts everything).
+/// Call `adbg_debugger_resume` to resume from a suspend.
+/// Params: process = Process instance.
+/// Returns: Error code.
+int adbg_debugger_suspend(adbg_process_t *process) {
+	if (process == null)
+		return adbg_oops(AdbgError.invalidArgument);
+	if ((process.status & ADBG_PROCESS_ATTACHED) == 0)
+		return adbg_oops(AdbgError.debuggerUnattached);
+	if (process.status & (ADBG_PROCESS_PAUSED | ADBG_PROCESS_SUSPENDED))
+		return adbg_oops(AdbgError.debuggerInvalidAction);
+
+version (Windows) {
+	if (__dynlib_ntdll_load())
+		return adbg_oops(AdbgError.unimplemented);
+	HANDLE phandle = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, cast(DWORD)process.pid);
+	if (phandle == null)
+		return adbg_oops(AdbgError.os);
+	scope(exit) CloseHandle(phandle);
+	if (NtSuspendProcess(phandle) != 0)
+		return adbg_oops(AdbgError.os);
+} else version (Posix) {
+	// On POSIX, ptrace intercepts SIGSTOP the same as pause
+	process.status |= ADBG_PROCESS_PAUSED; // for wait() correlation
+	if (kill(process.pid, SIGSTOP) < 0) {
+		process.status &= ~ADBG_PROCESS_PAUSED;
+		return adbg_oops(AdbgError.os);
+	}
+}
+	process.status |= ADBG_PROCESS_SUSPENDED;
+	return 0;
+}
+
+/// Resume the process from an OS-level suspend.
+///
+/// On Windows, uses NtResumeProcess.
+/// On POSIX, uses PTRACE_CONT (Linux) or PT_CONTINUE (FreeBSD).
+/// Params: process = Process instance.
+/// Returns: Error code.
+int adbg_debugger_resume(adbg_process_t *process) {
+	if (process == null)
+		return adbg_oops(AdbgError.invalidArgument);
+	if ((process.status & ADBG_PROCESS_ATTACHED) == 0)
+		return adbg_oops(AdbgError.debuggerUnattached);
+	if ((process.status & ADBG_PROCESS_SUSPENDED) == 0)
+		return adbg_oops(AdbgError.debuggerInvalidAction);
+
+version (Windows) {
+	if (__dynlib_ntdll_load())
+		return adbg_oops(AdbgError.unimplemented);
+	HANDLE phandle = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, cast(DWORD)process.pid);
+	if (phandle == null)
+		return adbg_oops(AdbgError.os);
+	scope(exit) CloseHandle(phandle);
+	if (NtResumeProcess(phandle) != 0)
+		return adbg_oops(AdbgError.os);
+} else version (linux) {
+	if (ptrace(PTRACE_CONT, process.pid, null, null) < 0)
+		return adbg_oops(AdbgError.os);
+} else version (Posix) {
+	if (ptrace(PT_CONTINUE, process.pid, cast(caddr_t)1, 0) < 0)
+		return adbg_oops(AdbgError.os);
+}
+	process.status &= ~(ADBG_PROCESS_SUSPENDED | ADBG_PROCESS_STOPPED | ADBG_PROCESS_PAUSED);
 	return 0;
 }
 

--- a/src/adbg/debugger.d
+++ b/src/adbg/debugger.d
@@ -55,16 +55,46 @@ version (Windows) {
 extern (C):
 
 /// Debugging events
-deprecated
+/// Used in both filtering and identification for wait function.
 enum AdbgEvent {
+	none,
+	
 	/// An exception occurred.
 	exception,
 	// A process was created.
-	//processCreated,
+	processCreated,
 	/// A process exited, or has been killed.
 	processExit,
 	/// A process continued.
 	processContinue,
+}
+
+/// Represents a debugger event.
+///
+/// This fixes a few issues with the past wait model:
+/// - Having callbacks on a blocking function makes the practice pretty pointless.
+///   It only increased data management for user code (and Easy API), hiding nothing
+///   of value because all of it was performed on a single thread.
+///   Instead, callbacks have been brought to Easy API, since it actually features
+///   a multithreaded message-based debugging loop.
+/// - Process instance storage. Reduce reliance on hacks (bring those here instead!)
+///   Instead, the affected process structure instance can comfortable live here,
+///   versus having to check DIFFERENT handles for both debugger-related handles
+///   and populating fake PIDs.
+/// - Having the wait function accept an event instance retains flexibility in terms
+///   of storage allocation, versus forcing it in global or TLS memory.
+/// - "Getter" functions can be use to get structure instances from this without
+///   punishing callbacks with specific types. They SHOULD be specific structures.
+struct adbg_event_t {
+	/// Event type.
+	AdbgEvent type;
+	
+	adbg_process_t process;
+	
+	union {
+	int exitcode;
+	adbg_exception_t exception;
+	}
 }
 
 version (Posix)
@@ -170,8 +200,8 @@ Loption:
 		return null;
 	}
 	
-	adbg_process_t *proc = cast(adbg_process_t*)calloc(1, adbg_process_t.sizeof);
-	if (proc == null) {
+	adbg_process_t *process = cast(adbg_process_t*)calloc(1, adbg_process_t.sizeof);
+	if (process == null) {
 		adbg_oops(AdbgError.crt);
 		return null;
 	}
@@ -185,12 +215,12 @@ version (Windows) {
 	DWORD fflags = GetFileAttributesA(path);
 	if (fflags == INVALID_FILE_ATTRIBUTES) {
 		adbg_oops(AdbgError.os);
-		free(proc);
+		free(process);
 		return null;
 	}
 	if (fflags & FILE_ATTRIBUTE_DIRECTORY) {
 		adbg_oops(AdbgError.debuggerNeedFile);
-		free(proc);
+		free(process);
 		return null;
 	}
 	
@@ -212,34 +242,34 @@ version (Windows) {
 		
 		// Allocate argument line space
 		size_t minlen = commlen + 2 + argslen + argc + 1; // + quotes and spaces
-		proc.orig_args = cast(char*)malloc(minlen);
-		if (proc.orig_args == null) {
-			adbg_process_free(proc);
+		process.orig_args = cast(char*)malloc(minlen);
+		if (process.orig_args == null) {
+			adbg_process_free(process);
 			adbg_oops(AdbgError.crt);
 			return null;
 		}
 		
 		// Place path into argv[0] with quotes
 		size_t i;
-		proc.orig_args[i++] = '"';
-		memcpy(proc.orig_args + i, path, commlen); i += commlen;
-		proc.orig_args[i++] = '"';
-		proc.orig_args[i++] = ' ';
+		process.orig_args[i++] = '"';
+		memcpy(process.orig_args + i, path, commlen); i += commlen;
+		process.orig_args[i++] = '"';
+		process.orig_args[i++] = ' ';
 		
 		// Flatten arguments
 		int cl = cast(int)minlen - cast(int)i; // Buffer space left
 		if (cl <= 0) {
-			adbg_process_free(proc);
+			adbg_process_free(process);
 			adbg_oops(AdbgError.assertion);
 			return null;
 		}
-		size_t o = adbg_strings_flatten(proc.orig_args + i, cl, argc, oargv, 1);
+		size_t o = adbg_strings_flatten(process.orig_args + i, cl, argc, oargv, 1);
 		if (o == 0) {
-			adbg_process_free(proc);
+			adbg_process_free(process);
 			adbg_oops(AdbgError.assertion);
 			return null;
 		}
-		version(Trace) trace("args='%s'", proc.orig_args);
+		version(Trace) trace("args='%s'", process.orig_args);
 	}
 	
 	// TODO: Parse envp
@@ -258,7 +288,7 @@ version (Windows) {
 	// Create process
 	if (CreateProcessA(
 		path,	// lpApplicationName
-		proc.orig_args,	// lpCommandLine
+		process.orig_args,	// lpCommandLine
 		null,	// lpProcessAttributes
 		null,	// lpThreadAttributes
 		FALSE,	// bInheritHandles
@@ -267,28 +297,28 @@ version (Windows) {
 		odir,	// lpCurrentDirectory
 		&si, &pi) == FALSE) {
 		adbg_oops(AdbgError.os);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
-	proc.orig_handle = pi.hProcess;
-	proc.orig_pid = proc.pid = pi.dwProcessId;
+	process.orig_handle = pi.hProcess;
+	process.orig_pid = process.pid = pi.dwProcessId;
 	
-	proc.state = AdbgProcessState.created;
-	proc.creation = AdbgCreation.spawned;
-	proc.option_timeout = INFINITE;
-	return proc;
+	process.state = AdbgProcessState.created;
+	process.creation = AdbgCreation.spawned;
+	process.option_timeout = INFINITE;
+	return process;
 } else version (Posix) {
 	// Verify if file exists and we has access to it
 	// This is to avoid a confusing error message
 	stat_t st = void;
 	if (stat(path, &st) < 0) {
 		adbg_oops(AdbgError.os);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
 	if (st.st_mode & S_IFDIR) {
 		adbg_oops(AdbgError.debuggerNeedFile);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
 	
@@ -296,17 +326,17 @@ version (Windows) {
 	int argc;
 	if (oargv) while (oargv[argc]) ++argc;
 	version(Trace) trace("argc=%d", argc);
-	proc.orig_argv = cast(char**)malloc((argc + 2) * size_t.sizeof);
-	if (proc.orig_argv == null) {
+	process.orig_argv = cast(char**)malloc((argc + 2) * size_t.sizeof);
+	if (process.orig_argv == null) {
 		version(Trace) trace("mmap=%s", strerror(errno));
 		adbg_oops(AdbgError.os);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
-	proc.orig_argv[0] = cast(char*)path;
+	process.orig_argv[0] = cast(char*)path;
 	if (argc && oargv && *oargv)
-		memcpy(proc.orig_argv + 1, oargv, argc * size_t.sizeof);
-	proc.orig_argv[argc + 1] = null;
+		memcpy(process.orig_argv + 1, oargv, argc * size_t.sizeof);
+	process.orig_argv[argc + 1] = null;
 	
 version (USE_CLONE) { // Use clone(2) for subprocess
 	// TODO: Assign stack to process for cleanup
@@ -315,7 +345,7 @@ version (USE_CLONE) { // Use clone(2) for subprocess
 		MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK,
 		-1, 0);
 	if (stack == MAP_FAILED) {
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		adbg_oops(AdbgError.os);
 		return null;
 	}
@@ -324,13 +354,13 @@ version (USE_CLONE) { // Use clone(2) for subprocess
 	
 	// Clone
 	__adbg_child_t chld = void;
-	chld.argv = cast(const(char)**)proc.argv;
+	chld.argv = cast(const(char)**)process.argv;
 	chld.envp = envp;
 	chld.dir  = dir;
-	proc.orig_pid =
-		proc.pid = clone(&__adbg_exec_child, stacktop, CLONE_PTRACE | CLONE_VFORK, &chld);
-	if (proc.pid < 0) {
-		adbg_process_free(proc);
+	process.orig_pid =
+		process.pid = clone(&__adbg_exec_child, stacktop, CLONE_PTRACE | CLONE_VFORK, &chld);
+	if (process.pid < 0) {
+		adbg_process_free(process);
 		adbg_oops(AdbgError.os);
 		return null;
 	}
@@ -339,31 +369,31 @@ version (USE_CLONE) { // Use clone(2) for subprocess
 	if (pid < 0) { // error
 		version(Trace) trace("fork=%s", strerror(errno));
 		adbg_oops(AdbgError.os);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
 	
 	if (pid == 0) { // sub process
 		version(Trace) for (int i; i < argc + 2; ++i)
-			trace("argv[%d]=%s", i, proc.orig_argv[i]);
+			trace("argv[%d]=%s", i, process.orig_argv[i]);
 		
 		__adbg_child_t chld = void;
-		chld.argv = cast(const(char)**)proc.orig_argv;
+		chld.argv = cast(const(char)**)process.orig_argv;
 		chld.envp = oenvp;
 		chld.dir  = odir;
 		if (__adbg_exec_child(&chld) < 0)
-			adbg_process_free(proc);
+			adbg_process_free(process);
 		version(Trace) trace("fork=%s", strerror(errno));
 		_exit(errno);
 	}
 	
-	proc.orig_pid = proc.pid = pid;
+	process.orig_pid = process.pid = pid;
 } // clone(2)/fork(2)
 	
-	version(Trace) trace("pid=%d", proc.pid);
-	proc.state = AdbgProcessState.created;
-	proc.creation = AdbgCreation.spawned;
-	return proc;
+	version(Trace) trace("pid=%d", process.pid);
+	process.state = AdbgProcessState.created;
+	process.creation = AdbgCreation.spawned;
+	return process;
 } else {
 	adbg_oops(AdbgError.unimplemented);
 	return null;
@@ -457,21 +487,21 @@ Loption:
 	}
 	
 	version (Trace) trace("pid=%d options=%#x", pid, options);
-	adbg_process_t *proc = cast(adbg_process_t*)calloc(1, adbg_process_t.sizeof);
-	if (proc == null) {
+	adbg_process_t *process = cast(adbg_process_t*)calloc(1, adbg_process_t.sizeof);
+	if (process == null) {
 		adbg_oops(AdbgError.crt);
 		return null;
 	}
 	
-	proc.creation = AdbgCreation.attached;
+	process.creation = AdbgCreation.attached;
 	
 version (Windows) {
 	//TODO: Integrate ObRegisterCallbacks?
 	//      https://blog.xpnsec.com/anti-debug-openprocess/
 	
-	proc.orig_pid = proc.pid = cast(DWORD)pid;
-	proc.orig_handle = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, cast(DWORD)pid);
-	if (proc.orig_handle == null) {
+	process.orig_pid = process.pid = cast(DWORD)pid;
+	process.orig_handle = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, cast(DWORD)pid);
+	if (process.orig_handle == null) {
 		switch (GetLastError()) {
 		case ERROR_INVALID_PARAMETER: // Must be invalid PID
 			adbg_oops(AdbgError.unfindable);
@@ -479,153 +509,93 @@ version (Windows) {
 		default: // ERROR_ACCESS_DENIED is a clear message
 			adbg_oops(AdbgError.os);
 		}
-		free(proc);
+		free(process);
 		return null;
 	}
 	
 	// Check if process already has an attached debugger
 	BOOL dbgpresent = void;
-	if (CheckRemoteDebuggerPresent(proc.orig_handle, &dbgpresent) == FALSE) {
+	if (CheckRemoteDebuggerPresent(process.orig_handle, &dbgpresent) == FALSE) {
 		adbg_oops(AdbgError.os);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
 	if (dbgpresent) {
 		adbg_oops(AdbgError.debuggerPresent);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
 	
 	// Breaks into remote process and initiates break-in
-	if (DebugActiveProcess(proc.pid) == FALSE) {
+	if (DebugActiveProcess(process.pid) == FALSE) {
 		adbg_oops(AdbgError.os);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
 	
 	// DebugActiveProcess, by default, kills the process on exit.
 	if (DebugSetProcessKillOnExit(options & OPT_EXITKILL) == FALSE) {
 		adbg_oops(AdbgError.os);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
 	
-	proc.option_timeout = INFINITE;
+	process.option_timeout = INFINITE;
 	// TODO: Continue process on OPT_STOP
 } else version (linux) {
 	version (Trace) if (options & OPT_STOP) trace("Sending break...");
 	if (ptrace(options & OPT_STOP ? PTRACE_ATTACH : PTRACE_SEIZE, pid, null, null) < 0) {
 		adbg_oops(AdbgError.os);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
 	
 	// Set exitkill on if specified, it is off by default
 	if (options & OPT_EXITKILL && ptrace(PTRACE_SETOPTIONS, pid, null, PTRACE_O_EXITKILL) < 0) {
 		adbg_oops(AdbgError.os);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
 	
-	proc.state = options & OPT_STOP ? AdbgProcessState.stopped : AdbgProcessState.running;
-	proc.orig_pid = proc.pid = cast(pid_t)pid;
+	process.state = options & OPT_STOP ? AdbgProcessState.stopped : AdbgProcessState.running;
+	process.orig_pid = process.pid = cast(pid_t)pid;
 } else version (FreeBSD) {
 	if (ptrace(PT_ATTACH, pid, null, 0) < 0) {
 		adbg_oops(AdbgError.os);
-		adbg_process_free(proc);
+		adbg_process_free(process);
 		return null;
 	}
 	
-	proc.state = AdbgProcessState.paused;
-	proc.orig_pid = proc.pid = cast(pid_t)pid;
+	process.state = AdbgProcessState.paused;
+	process.orig_pid = process.pid = cast(pid_t)pid;
 }
 	
-	proc.creation = AdbgCreation.attached;
-	return proc;
+	process.creation = AdbgCreation.attached;
+	return process;
 }
 
 /// Detach debugger from current process.
-/// Params: proc = Process instance being debugged.
+/// Params: process = Process instance being debugged.
 /// Returns: Error code.
-int adbg_debugger_detach(adbg_process_t *proc) {
-	if (proc == null)
+int adbg_debugger_detach(adbg_process_t *process) {
+	if (process == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	if (proc.creation != AdbgCreation.attached)
+	if (process.creation != AdbgCreation.attached)
 		return adbg_oops(AdbgError.debuggerInvalidAction);
 	
-	proc.creation = AdbgCreation.unloaded;
-	proc.state = AdbgProcessState.unknown;
+	process.creation = AdbgCreation.unloaded;
+	process.state = AdbgProcessState.unknown;
 	
 version (Windows) {
-	if (DebugActiveProcessStop(proc.pid) == FALSE)
+	if (DebugActiveProcessStop(process.pid) == FALSE)
 		return adbg_oops(AdbgError.os);
 } else version (linux) {
-	if (ptrace(PTRACE_DETACH, proc.pid, null, null) < 0)
+	if (ptrace(PTRACE_DETACH, process.pid, null, null) < 0)
 		return adbg_oops(AdbgError.os);
 } else version (Posix) {
-	if (ptrace(PT_DETACH, proc.pid, null, 0) < 0)
+	if (ptrace(PT_DETACH, process.pid, null, 0) < 0)
 		return adbg_oops(AdbgError.os);
 }
-	return 0;
-}
-
-// NOTE: adbg_debugger_on_* advantages over adbg_debugger_on(enum)
-//       - Callback type checking (when source compiling)
-//       - Access to attributes (like `deprecated`) per function
-//       - No need to map and update enumeration values
-//       - Better documentation per function
-
-/// Set an event handler for handling exceptions when they occur for
-/// an attached process.
-///
-/// The callback will receive the active process (`adbg_process_t*`),
-/// user data (`void*`), and the exception (`adbg_exception_t*`).
-/// It must not return (`void`).
-/// Params:
-/// 	proc = Active process instance.
-/// 	callback = Callback function. Set to null to disable.
-/// Returns: Error code.
-int adbg_debugger_on_exception(adbg_process_t *proc,
-	void function(adbg_process_t*, void*, adbg_exception_t*) callback) {
-	if (proc == null)
-		return adbg_oops(AdbgError.invalidArgument);
-	proc.event_exception = callback;
-	return 0;
-}
-
-/// Set an event handler to know when the attached process exits.
-///
-/// The callback will receive the active process (`adbg_process_t*`),
-/// user data (`void*`), and the exit code (`int`).
-/// It must not return (`void`).
-/// Params:
-/// 	proc = Active process instance.
-/// 	callback = Callback function. Set to null to disable.
-/// Returns: Error code.
-int adbg_debugger_on_process_exit(adbg_process_t *proc,
-	void function(adbg_process_t*, void*, int) callback) {
-	if (proc == null)
-		return adbg_oops(AdbgError.invalidArgument);
-	proc.event_process_exited = callback;
-	return 0;
-}
-
-/// Set an event handler to know when the attached process continues.
-///
-/// This includes continue and step events.
-///
-/// The callback will receive the active process (`adbg_process_t*`),
-/// user data (`void*`), and thread/job ID (`long`).
-/// It must not return (`void`).
-/// Params:
-/// 	proc = Active process instance.
-/// 	callback = Callback function. Set to null to disable.
-/// Returns: Error code.
-int adbg_debugger_on_process_continue(adbg_process_t *proc,
-	void function(adbg_process_t*, void*, long) callback) {
-	if (proc == null)
-		return adbg_oops(AdbgError.invalidArgument);
-	proc.event_process_continued = callback;
 	return 0;
 }
 
@@ -634,64 +604,75 @@ int adbg_debugger_on_process_continue(adbg_process_t *proc,
 /// User data is sent to event callback functions, for example, useful to
 /// personally identify debugger requests.
 /// Params:
-/// 	proc = Process instance.
+/// 	process = Process instance.
 /// 	udata = User data pointer. Passing null clears it.
 /// Returns: Error code.
-int adbg_debugger_udata(adbg_process_t *proc, void *udata) {
-	if (proc == null)
+int adbg_debugger_udata(adbg_process_t *process, void *udata) {
+	if (process == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	proc.udata = udata;
+	process.udata = udata;
 	return 0;
 }
 
+// NOTE: This is a hack, which might be removed later
 /// Sets a timeout when waiting for a debug event to occur.
 /// 
 /// This function is only effective for adbg_debugger_wait on Windows.
 /// Params:
-/// 	proc = Process instance.
-/// 	ms = Timeout in milliseconds.
+/// 	process = Process instance.
+/// 	ms = Timeout in milliseconds. 0 for infinite.
 /// Returns: Error code.
-int adbg_debugger_option_wait_timeout(adbg_process_t *proc, uint ms) {
-	if (proc == null)
+int adbg_debugger_option_wait_timeout(adbg_process_t *process, uint ms) {
+	if (process == null)
 		return adbg_oops(AdbgError.invalidArgument);
 version (Windows) {
-	proc.option_timeout = ms == 0 ? INFINITE : ms;
+	process.option_timeout = ms == 0 ? INFINITE : ms;
 	return 0;
 } else {
-	return adbg_oops(AdbgError.unimplemented);	
+	return adbg_oops(AdbgError.unimplemented);
 }
 }
 
+// NOTE: Wait function: Keep it simple!
+//
+//       The process and event parameters are absolute minimum.
+//       A timeout option is only useful on Windows.
+//       A "filter" int increases complexity pointlessly (user code can filter events itself).
+//
+//       The process return indicates which process was affected, and again,
+//       user code can filter itself.
+
 /// Wait until a new debug event occurs. This call is blocking.
 ///
-/// The lifetime of the event callback parameters are not guaranteed.
-/// To keep a reference, use the proper duplicate function (when that is implemented).
+/// The process instance returned corresponds to the debugging event.
 ///
-/// Note that on Windows, debugger and wait calls must be performed on the
-/// same thread. This debugger module does not yet provide a debugger loop.
+/// Windows: Uses WaitForDebugEvent. Needs to be on the same thread as other debugger calls.
+/// POSIX: Uses waitpid.2 and ptrace.2 for further information.
 ///
-/// Windows: Uses WaitForDebugEvent.
-/// POSIX: Uses waitpid(2) and ptrace(2).
-///
-/// Params: proc = Process instance created by debugger.
-/// Returns: Error code.
-int adbg_debugger_wait(adbg_process_t *proc) {
-	version(Trace) trace("proc=%p", proc);
+/// Params: process = Process instance created by debugger.
+/// Returns: Affected process instance by debugging event. Or null on error.
+adbg_process_t* adbg_debugger_wait(scope adbg_process_t *process, scope adbg_event_t *event) {
+	version(Trace) trace("process=%p", process);
 	
-	if (proc == null)
-		return adbg_oops(AdbgError.invalidArgument);
-	if (proc.creation == AdbgCreation.unloaded)
-		return adbg_oops(AdbgError.debuggerUnattached);
+	if (process == null || event == null) {
+		adbg_oops(AdbgError.invalidArgument);
+		return null;
+	}
+	if (process.creation == AdbgCreation.unloaded) {
+		adbg_oops(AdbgError.debuggerUnattached);
+		return null;
+	}
 	
 version (Windows) {
 	DEBUG_EVENT de = void;
 Lwait:
-	if (WaitForDebugEvent(&de, proc.option_timeout) == FALSE) {
-		proc.state = AdbgProcessState.unknown;
-		return adbg_oops(AdbgError.os);
+	if (WaitForDebugEvent(&de, process.option_timeout) == FALSE) {
+		process.state = AdbgProcessState.unknown;
+		return null;
 	}
 	
-	proc.pid = de.dwProcessId;
+	event.process.pid = de.dwProcessId;
+	event.process.option_timeout = process.option_timeout;
 	
 	// Filter events
 	switch (de.dwDebugEventCode) {
@@ -700,35 +681,30 @@ Lwait:
 			de.dwProcessId, de.dwThreadId,
 			de.Exception.ExceptionRecord.ExceptionCode);
 		
-		proc.state = AdbgProcessState.stopped;
+		event.type = AdbgEvent.exception;
 		
-		// If exception event handler is unset, continue
-		if (proc.event_exception == null)
-			goto Lcontinue;
+		event.process.state = AdbgProcessState.stopped;
+		event.process.pid = de.dwProcessId;
 		
 		adbg_exception_t exception = void;
-		adbg_translate_exception(&exception, proc, &de);
-		
+		adbg_translate_exception(&exception, process, &de);
 		// HACK: fill up thread details for exception
-		exception.thread.process = proc;
-		exception.thread.id = de.dwThreadId;
-		exception.thread.status = 0;
+		exception.thread.id      = de.dwThreadId;
+		exception.thread.process = process;
+		exception.thread.status  = 0;
+		return &event.process;
 		
-		// Call event handler
-		proc.event_exception(proc, proc.udata, &exception);
-		break;
+		//goto Lcontinue; // auto-continue
 	case EXIT_PROCESS_DEBUG_EVENT:
 		version(Trace) trace("ProcExit pid=%d tid=%d code=%u",
 			de.dwProcessId, de.dwThreadId, de.ExitProcess.dwExitCode);
 		
-		proc.state = AdbgProcessState.unknown;
+		event.process.state = AdbgProcessState.unknown;
 		
-		// If process exit event handler is unset, continue
-		if (proc.event_process_exited == null)
-			goto Lcontinue;
-		
-		proc.event_process_exited(proc, proc.udata, cast(int)de.ExitProcess.dwExitCode);
-		break;
+		event.type = AdbgEvent.processExit;
+		event.exitcode = cast(int)de.ExitProcess.dwExitCode;
+			
+		return &event.process; // can't wait on a dead process
 	/*case CREATE_THREAD_DEBUG_EVENT:
 	case CREATE_PROCESS_DEBUG_EVENT:
 	case EXIT_THREAD_DEBUG_EVENT:
@@ -740,10 +716,9 @@ Lwait:
 	default:
 		version(Trace) trace("Unknown event=%u pid=%d tid=%d",
 			de.dwDebugEventCode, de.dwProcessId, de.dwThreadId);
-	Lcontinue: // Label exists to bypass trace call
-		ContinueDebugEvent(de.dwProcessId, de.dwThreadId, DBG_CONTINUE);
-		goto Lwait;
 	}
+	ContinueDebugEvent(de.dwProcessId, de.dwThreadId, DBG_CONTINUE);
+	goto Lwait;
 } else version (Posix) {
 	version (linux) enum WBASE = __WALL; // all threads
 	else            enum WBASE = 0;
@@ -752,65 +727,84 @@ Lwait:
 	// TODO: Check process flag to debug all subprocesses instead of -1
 	// NOTE: WCONTINUED does not work on Linux, even when sending SIGCONT
 	//       ptrace(2) manpage states that setting WCONTINUED is not recommended
-	if ((proc.pid = waitpid(-1, &wstatus, WBASE)) < 0) {
-		proc.state = AdbgProcessState.unknown;
-		return adbg_oops(AdbgError.crt);
+	pid_t pid = waitpid(-1, &wstatus, WBASE);
+	if (pid < 0) {
+		event.process.state = AdbgProcessState.unknown;
+		adbg_oops(AdbgError.crt);
+		return null;
 	}
 	
 	if (WIFEXITED(wstatus) || WIFSIGNALED(wstatus)) { // exited or killed
-		version (Trace) trace("Exit/Signal status=%#x pid=%d", wstatus, proc.pid);
+		version (Trace) trace("Exit/Signal status=%#x pid=%d", wstatus, process.pid);
 		
-		proc.state = AdbgProcessState.unknown;
+		// Can't really filter out process exits, can't wait on a dead process
+		process.state = AdbgProcessState.unknown;
+		event.type = AdbgEvent.processExit;
+		event.exitcode = WTERMSIG(wstatus);
+	/*} else if (WIFCONTINUED(wstatus)) { // SIGCONT (from a previous pause.2, not ptrace.2)
+		version (Trace) trace("Continued status=%#x pid=%d", wstatus, process.pid);
 		
-		// If process exit event handler is set, call it
-		if (proc.event_process_exited)
-			proc.event_process_exited(proc, proc.udata, WTERMSIG(wstatus));
-	/*} else if (WIFCONTINUED(wstatus)) { // continuing
-		version (Trace) trace("Continued status=%#x pid=%d", wstatus, proc.pid);
+		process.state = AdbgProcessState.running; // just in case
 		
-		proc.state = AdbgProcessState.running; // just in case
-		
-		if (proc.event_process_continued)
-			proc.event_process_continued(proc, udata);*/
+		if (process.event_process_continued)
+			process.event_process_continued(process, udata);*/
 	} else if (WIFSTOPPED(wstatus)) { // stopped by signal
-		version (Trace) trace("Stopped status=%#x pid=%d", wstatus, proc.pid);
+		version (Trace) trace("Stopped status=%#x pid=%d", wstatus, process.pid);
 		
-		proc.state = AdbgProcessState.stopped;
-		
-		// If exception event handler is unset, continue
-		if (proc.event_exception == null) {
-			int e = adbg_debugger_continue(proc, proc.pid);
-			if (e) return e;
-			goto Lwait;
-		}
-		
-		adbg_exception_t exception = void;
+		event.type = AdbgEvent.exception;
 		// HACK: To allow thread services, we assume that the TID is equal to PID.
 		//       This is partially true, the initial TID on Linux is the same as
 		//       of the PID, and while Linux ptrace calls refer to the TID,
 		//       this holds up for the moment being, but will fall short when
 		//       multiple processes and threads come into play.
-		int stopsig = WSTOPSIG(wstatus);
-		adbg_translate_exception(&exception, proc, &stopsig);
+		event.process.pid = pid;
+		event.process.state = AdbgProcessState.stopped;
+		
+		int signo = WSTOPSIG(wstatus);
+		
+		// Get subcode and fault address if available
+		siginfo_t siginfo = void;
+		int si_code = void;
+		if (ptrace(PTRACE_GETSIGINFO, process.pid, null, &siginfo) < 0) {
+			si_code = 0;
+			event.exception.fault_address = 0;
+		} else {
+			si_code = siginfo.si_code;
+			switch (signo) { // Get fault address
+			case SIGILL, SIGSEGV, SIGFPE, SIGBUS:
+				// NOTE: .si_addr() emits linker errors on Musl platforms.
+				event.exception.fault_address =
+					cast(ulong)siginfo._sifields._sigfault.si_addr;
+				break;
+			default:
+				event.exception.fault_address = 0;
+			}
+		}
+		
+		event.exception.type = adbg_exception_from_os(signo, si_code);
+		event.exception.oscode = signo;
 		
 		// HACK: fill up thread details for exception
-		exception.thread.process = proc;
-		exception.thread.id = proc.pid;
-		exception.thread.status = 0;
+		event.exception.thread.process = &event.process;
+		event.exception.thread.id      = event.process.pid;
+		event.exception.thread.status  = 0;
+		return &event.process;
 		
-		proc.event_exception(proc, proc.udata, &exception);
+		//int e = adbg_debugger_continue(process, process.pid);
+		//if (e) return null;
+		//goto Lwait;
 	} else {
 		version (Trace) trace("Unknown status=%d", wstatus);
 		goto Lwait;
 	}
+	
+	return &event.process;
 } else static assert(0, "Implement adbg_debugger_wait");
-
-	return 0;
 }
 
 // Used internally to translate OS codes into exception
 private
-void adbg_translate_exception(adbg_exception_t *exception, adbg_process_t *proc, void *osevent) {
+void adbg_translate_exception(adbg_exception_t *exception, adbg_process_t *process, void *osevent) {
 version (Windows) {
 	assert(osevent);
 	DEBUG_EVENT *event = cast(DEBUG_EVENT*)osevent;
@@ -827,17 +821,17 @@ version (Windows) {
 	
 	// HACK: fill up thread details for exception
 	exception.thread.id = event.dwThreadId;
-	exception.thread.process = proc;
+	exception.thread.process = process;
 	exception.thread.status = 0;
 } else version (linux) {
-	assert(proc);
+	assert(process);
 	assert(osevent);
 	int signo = *cast(int*)osevent;
 	int si_code = void;
 	
 	// Get subcode and fault address if available
 	siginfo_t siginfo = void;
-	if (ptrace(PTRACE_GETSIGINFO, proc.pid, null, &siginfo) < 0) {
+	if (ptrace(PTRACE_GETSIGINFO, process.pid, null, &siginfo) < 0) {
 		si_code = 0;
 		exception.fault_address = 0;
 	} else {
@@ -856,18 +850,18 @@ version (Windows) {
 	exception.oscode = signo;
 	
 	// HACK: fill up thread details for exception
-	exception.thread.id = proc.pid;
-	exception.thread.process = proc;
+	exception.thread.id = process.pid;
+	exception.thread.process = process;
 	exception.thread.status = 0;
 } else version (FreeBSD) {
-	assert(proc);
+	assert(process);
 	assert(osevent);
 	int signo = *cast(int*)osevent;
 	int si_code = void;
 	
 	// Get subcode fault address if available
 	ptrace_lwpinfo lwp = void;
-	if (ptrace(PT_LWPINFO, proc.pid, &lwp, 0) < 0) {
+	if (ptrace(PT_LWPINFO, process.pid, &lwp, 0) < 0) {
 		si_code = 0;
 		exception.fault_address = 0;
 	} else {
@@ -880,7 +874,7 @@ version (Windows) {
 	
 	// HACK: fill up thread details for exception
 	exception.thread.id = de.dwThreadId;
-	exception.thread.process = proc;
+	exception.thread.process = process;
 	exception.thread.status = 0;
 } else {
 	static assert(false, "Implement exception translation code");
@@ -888,16 +882,16 @@ version (Windows) {
 }
 
 /// Disconnect and terminate the debuggee process.
-/// Params: proc = Process.
+/// Params: process = Process.
 /// Returns: Error code.
-int adbg_debugger_terminate(adbg_process_t *proc) {
-	if (proc == null)
+int adbg_debugger_terminate(adbg_process_t *process) {
+	if (process == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	if (proc.creation == AdbgCreation.unloaded || proc.pid == 0)
+	if (process.creation == AdbgCreation.unloaded || process.pid == 0)
 		return adbg_oops(AdbgError.debuggerUnattached);
 	
 version (Windows) {
-	HANDLE phandle = OpenProcess(PROCESS_TERMINATE, FALSE, cast(DWORD)proc.pid);
+	HANDLE phandle = OpenProcess(PROCESS_TERMINATE, FALSE, cast(DWORD)process.pid);
 	if (phandle == null)
 		return adbg_oops(AdbgError.os);
 	scope(exit) CloseHandle(phandle);
@@ -910,60 +904,58 @@ version (Windows) {
 		return adbg_oops(AdbgError.os);
 } else version (Posix) {
 	// PT_KILL is deprecated on Linux, and likely everywhere else too
-	if (kill(proc.pid, SIGKILL) < 0)
+	if (kill(process.pid, SIGKILL) < 0)
 		return adbg_oops(AdbgError.os);
 } else static assert(0, "Implement adbg_debugger_terminate");
 
-	proc.state = AdbgProcessState.unknown;
-	proc.creation = AdbgCreation.unloaded;
+	process.state = AdbgProcessState.unknown;
+	process.creation = AdbgCreation.unloaded;
 	return 0;
 }
 
 /// Make the debuggee process continue from its currently stopped state.
 /// Params:
-/// 	proc = Process instance.
+/// 	process = Process instance.
 /// 	tid = Thread or process ID.
 /// Returns: Error code.
-int adbg_debugger_continue(adbg_process_t *proc, long tid) {
-	if (proc == null)
+int adbg_debugger_continue(adbg_process_t *process, long tid) {
+	if (process == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	if (proc.creation == AdbgCreation.unloaded)
+	if (process.creation == AdbgCreation.unloaded)
 		return adbg_oops(AdbgError.debuggerUnattached);
 	
 version (Windows) {
-	version(Trace) trace("pid=%d tid=%lld state=%d", proc.pid, tid, proc.state);
-	switch (proc.state) with (AdbgProcessState) {
+	version(Trace) trace("pid=%d tid=%lld state=%d", process.pid, tid, process.state);
+	switch (process.state) with (AdbgProcessState) {
 	// HACK: Created processes are not in a "stopped" state
 	//       But will continue at the next wait call
 	case created: break;
 	case stopped:
-		if (ContinueDebugEvent(proc.pid, cast(DWORD)tid, DBG_CONTINUE) == FALSE) {
-			proc.state = AdbgProcessState.unknown;
+		if (ContinueDebugEvent(process.pid, cast(DWORD)tid, DBG_CONTINUE) == FALSE) {
+			process.state = AdbgProcessState.unknown;
 			return adbg_oops(AdbgError.os);
 		}
 		break;
 	default: return adbg_oops(AdbgError.debuggerUnpaused);
 	}
 	
-	if (proc.event_process_continued)
-		proc.event_process_continued(proc, proc.udata, tid);
+	//if (process.event_process_continued)
+	//	process.event_process_continued(process, process.udata, tid);
 } else version (linux) {
-	version(Trace) trace("pid=%d state=%d", proc.pid, proc.state);
-	switch (proc.state) with (AdbgProcessState) {
-	case created, stopped:
-		if (ptrace(PTRACE_CONT, proc.pid, null, null) < 0) {
+	version(Trace) trace("pid=%d state=%d", process.pid, process.state);
+	switch (process.state) with (AdbgProcessState) {
+	case created, stopped: // attached or stopped
+		if (ptrace(PTRACE_CONT, process.pid, null, null) < 0) {
 			version (Trace) trace("ptrace=%s", strerror(errno));
-			proc.state = AdbgProcessState.unknown;
+			process.state = AdbgProcessState.unknown;
 			return adbg_oops(AdbgError.os);
 		}
-		if (proc.event_process_continued)
-			proc.event_process_continued(proc, proc.udata, tid);
 		break;
 	default: return adbg_oops(AdbgError.debuggerUnpaused);
 	}
 } else version (Posix) {
-	version(Trace) trace("pid=%d state=%d", proc.pid, proc.state);
-	switch (proc.state) with (AdbgProcessState) {
+	version(Trace) trace("pid=%d state=%d", process.pid, process.state);
+	switch (process.state) with (AdbgProcessState) {
 	case created:
 		// TODO: Test HACK on NetBSD, OpenBSD
 		// HACK: FreeBSD: PT_TRACEME and stop state.
@@ -980,17 +972,17 @@ version (Windows) {
 		//       data can be a signal number, or 0
 		if (ptrace(PT_CONTINUE, cast(pid_t)tid, cast(caddr_t)1, 0) < 0) {
 			version (Trace) trace("ptrace=%s", strerror(errno));
-			proc.state = AdbgProcessState.unknown;
+			process.state = AdbgProcessState.unknown;
 			return adbg_oops(AdbgError.os);
 		}
-		if (proc.event_process_continued)
-			proc.event_process_continued(proc, proc.udata, tid);
+		if (process.event_process_continued)
+			process.event_process_continued(process, process.udata, tid);
 		break;
 	default: return adbg_oops(AdbgError.debuggerUnpaused);
 	}
 } else static assert(0, "Implement adbg_debugger_continue");
 	
-	proc.state = AdbgProcessState.running;
+	process.state = AdbgProcessState.running;
 	return 0;
 }
 
@@ -998,13 +990,13 @@ version (Windows) {
 ///
 /// This will trigger a step exception.
 /// Params:
-/// 	proc = Process instance.
+/// 	process = Process instance.
 /// 	tid = Thread or process ID, typically from a stopped event.
 /// Returns: Error code.
-int adbg_debugger_step_instruction(adbg_process_t *proc, long tid) {
-	if (proc == null)
+int adbg_debugger_step_instruction(adbg_process_t *process, long tid) {
+	if (process == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	if (proc.creation == AdbgCreation.unloaded)
+	if (process.creation == AdbgCreation.unloaded)
 		return adbg_oops(AdbgError.debuggerUnattached);
 	
 version (WinTel) {
@@ -1015,7 +1007,7 @@ version (WinTel) {
 		return adbg_oops(AdbgError.os);
 	scope(exit) CloseHandle(thandle);
 
-	HANDLE phandle = OpenProcess(PROCESS_SET_INFORMATION, FALSE, cast(DWORD)proc.pid);
+	HANDLE phandle = OpenProcess(PROCESS_SET_INFORMATION, FALSE, cast(DWORD)process.pid);
 	if (phandle == null)
 		return adbg_oops(AdbgError.os);
 	scope(exit) CloseHandle(phandle);
@@ -1023,7 +1015,7 @@ version (WinTel) {
 	// AMD64 with a 32-bit process
 	// Enable single-stepping via Trap flag
 	version (X86_64)
-	if (adbg_process_machine(proc) == AdbgMachine.i386) {
+	if (adbg_process_machine(process) == AdbgMachine.i386) {
 		WOW64_CONTEXT wow64ctx = void;
 		wow64ctx.ContextFlags = CONTEXT_CONTROL;
 		if (Wow64GetThreadContext(thandle, &wow64ctx) == FALSE)
@@ -1034,7 +1026,7 @@ version (WinTel) {
 		if (FlushInstructionCache(phandle, null, 0) == FALSE)
 			return adbg_oops(AdbgError.os);
 		
-		return adbg_debugger_continue(proc, tid);
+		return adbg_debugger_continue(process, tid);
 	}
 	
 	// X86, AMD64
@@ -1049,7 +1041,7 @@ version (WinTel) {
 	if (FlushInstructionCache(phandle, null, 0) == FALSE)
 		return adbg_oops(AdbgError.os);
 	
-	return adbg_debugger_continue(proc, tid);
+	return adbg_debugger_continue(process, tid);
 } else version (WinArm) {
 	enum PSTATE_SS = 0x200000;
 	
@@ -1060,7 +1052,7 @@ version (WinTel) {
 		return adbg_oops(AdbgError.os);
 	scope(exit) CloseHandle(thandle);
 
-	HANDLE phandle = OpenProcess(PROCESS_SET_INFORMATION, FALSE, cast(DWORD)proc.pid);
+	HANDLE phandle = OpenProcess(PROCESS_SET_INFORMATION, FALSE, cast(DWORD)process.pid);
 	if (phandle == null)
 		return adbg_oops(AdbgError.os);
 	scope(exit) CloseHandle(phandle);
@@ -1068,7 +1060,7 @@ version (WinTel) {
 	// AArch64 with a 32-bit process
 	// Enable single-stepping via SS bit
 	version (AArch64)
-	switch (adbg_process_machine(proc)) with (AdbgMachine) {
+	switch (adbg_process_machine(process)) with (AdbgMachine) {
 	case arm, thumb, thumb32:
 		WOW64_CONTEXT wow64ctx = void;
 		wow64ctx.ContextFlags = CONTEXT_CONTROL;
@@ -1080,7 +1072,7 @@ version (WinTel) {
 		if (FlushInstructionCache(phandle, null, 0) == FALSE)
 			return adbg_oops(AdbgError.os);
 		
-		return adbg_debugger_continue(proc, tid);
+		return adbg_debugger_continue(process, tid);
 	}
 	
 	// AArch64, AArch32
@@ -1095,18 +1087,18 @@ version (WinTel) {
 	if (FlushInstructionCache(phandle, null, 0) == FALSE)
 		return adbg_oops(AdbgError.os);
 	
-	return adbg_debugger_continue(proc, tid);
+	return adbg_debugger_continue(process, tid);
 } else version (linux) {
 	if (ptrace(PTRACE_SINGLESTEP, tid, null, null) < 0) {
-		proc.state = AdbgProcessState.unknown;
+		process.state = AdbgProcessState.unknown;
 		return adbg_oops(AdbgError.os);
 	}
-	if (proc.event_process_continued)
-		proc.event_process_continued(proc, proc.udata, tid);
+	//if (process.event_process_continued)
+	//	process.event_process_continued(process, process.udata, tid);
 	
 	return 0;
 } else version (Posix) {
-	switch (proc.state) with (AdbgProcessState) {
+	switch (process.state) with (AdbgProcessState) {
 	case created:
 		// HACK: See HACK in continue function.
 		int w = void;
@@ -1116,11 +1108,11 @@ version (WinTel) {
 	}
 	
 	if (ptrace(PT_STEP, cast(pid_t)tid, null, 0) < 0) {
-		proc.state = AdbgProcessState.unknown;
+		process.state = AdbgProcessState.unknown;
 		return adbg_oops(AdbgError.os);
 	}
-	if (proc.event_process_continued)
-		proc.event_process_continued(proc, proc.udata, tid);
+	if (process.event_process_continued)
+		process.event_process_continued(process, process.udata, tid);
 	
 	return 0;
 } else {

--- a/src/adbg/debugger.d
+++ b/src/adbg/debugger.d
@@ -391,8 +391,7 @@ version (USE_CLONE) { // Use clone(2) for subprocess
 } // clone(2)/fork(2)
 	
 	version(Trace) trace("pid=%d", process.pid);
-	process.state = AdbgProcessState.created;
-	process.creation = AdbgCreation.spawned;
+	process.status = ADBG_PROCESS_ATTACHED;
 	return process;
 } else {
 	adbg_oops(AdbgError.unimplemented);
@@ -493,7 +492,7 @@ Loption:
 		return null;
 	}
 	
-	process.creation = AdbgCreation.attached;
+	process.status = ADBG_PROCESS_ATTACHED;
 	
 version (Windows) {
 	//TODO: Integrate ObRegisterCallbacks?
@@ -533,7 +532,7 @@ version (Windows) {
 		return null;
 	}
 	
-	// DebugActiveProcess, by default, kills the process on exit.
+	// DebugActiveProcess, the default kills the process on exit.
 	if (DebugSetProcessKillOnExit(options & OPT_EXITKILL) == FALSE) {
 		adbg_oops(AdbgError.os);
 		adbg_process_free(process);
@@ -557,20 +556,20 @@ version (Windows) {
 		return null;
 	}
 	
-	process.state = options & OPT_STOP ? AdbgProcessState.stopped : AdbgProcessState.running;
+	if (options & OPT_STOP)
+		process.status |= ADBG_PROCESS_STOPPED;
+	
 	process.orig_pid = process.pid = cast(pid_t)pid;
-} else version (FreeBSD) {
+} else version (Posix) { // BSDs, macOS
 	if (ptrace(PT_ATTACH, pid, null, 0) < 0) {
 		adbg_oops(AdbgError.os);
 		adbg_process_free(process);
 		return null;
 	}
 	
-	process.state = AdbgProcessState.paused;
 	process.orig_pid = process.pid = cast(pid_t)pid;
 }
 	
-	process.creation = AdbgCreation.attached;
 	return process;
 }
 
@@ -580,11 +579,10 @@ version (Windows) {
 int adbg_debugger_detach(adbg_process_t *process) {
 	if (process == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	if (process.creation != AdbgCreation.attached)
+	if ((process.status & ADBG_PROCESS_ATTACHED) == 0)
 		return adbg_oops(AdbgError.debuggerInvalidAction);
 	
-	process.creation = AdbgCreation.unloaded;
-	process.state = AdbgProcessState.unknown;
+	process.status = 0;
 	
 version (Windows) {
 	if (DebugActiveProcessStop(process.pid) == FALSE)
@@ -658,7 +656,7 @@ adbg_process_t* adbg_debugger_wait(scope adbg_process_t *process, scope adbg_eve
 		adbg_oops(AdbgError.invalidArgument);
 		return null;
 	}
-	if (process.creation == AdbgCreation.unloaded) {
+	if ((process.status & ADBG_PROCESS_ATTACHED) == 0) {
 		adbg_oops(AdbgError.debuggerUnattached);
 		return null;
 	}
@@ -680,11 +678,12 @@ Lwait:
 		version(Trace) trace("Exception pid=%d tid=%d code=%#x",
 			de.dwProcessId, de.dwThreadId,
 			de.Exception.ExceptionRecord.ExceptionCode);
+	
+		process.status |= ADBG_PROCESS_STOPPED;
 		
 		event.type = AdbgEvent.exception;
 		
-		event.process.state = AdbgProcessState.stopped;
-		event.process.pid = de.dwProcessId;
+		event.process.status = process.status;
 		
 		adbg_exception_t exception = void;
 		adbg_translate_exception(&exception, process, &de);
@@ -699,10 +698,12 @@ Lwait:
 		version(Trace) trace("ProcExit pid=%d tid=%d code=%u",
 			de.dwProcessId, de.dwThreadId, de.ExitProcess.dwExitCode);
 		
-		event.process.state = AdbgProcessState.unknown;
-		
 		event.type = AdbgEvent.processExit;
 		event.exitcode = cast(int)de.ExitProcess.dwExitCode;
+		
+		process.status |= ADBG_PROCESS_EXITED;
+		
+		event.process.status = process.status;
 			
 		return &event.process; // can't wait on a dead process
 	/*case CREATE_THREAD_DEBUG_EVENT:
@@ -729,18 +730,25 @@ Lwait:
 	//       ptrace(2) manpage states that setting WCONTINUED is not recommended
 	pid_t pid = waitpid(-1, &wstatus, WBASE);
 	if (pid < 0) {
-		event.process.state = AdbgProcessState.unknown;
 		adbg_oops(AdbgError.crt);
 		return null;
 	}
 	
+	// HACK: To allow thread services, we assume that the TID is equal to PID.
+	//       This is partially true, the initial TID on Linux is the same as
+	//       of the PID, and while Linux ptrace calls refer to the TID,
+	//       this holds up for the moment being, but will fall short when
+	//       multiple processes and threads come into play.
+	event.process.pid = pid;
+	
 	if (WIFEXITED(wstatus) || WIFSIGNALED(wstatus)) { // exited or killed
 		version (Trace) trace("Exit/Signal status=%#x pid=%d", wstatus, process.pid);
 		
-		// Can't really filter out process exits, can't wait on a dead process
-		process.state = AdbgProcessState.unknown;
 		event.type = AdbgEvent.processExit;
 		event.exitcode = WTERMSIG(wstatus);
+		
+		process.status |= ADBG_PROCESS_EXITED;
+		event.process.status = process.status;
 	/*} else if (WIFCONTINUED(wstatus)) { // SIGCONT (from a previous pause.2, not ptrace.2)
 		version (Trace) trace("Continued status=%#x pid=%d", wstatus, process.pid);
 		
@@ -752,37 +760,13 @@ Lwait:
 		version (Trace) trace("Stopped status=%#x pid=%d", wstatus, process.pid);
 		
 		event.type = AdbgEvent.exception;
-		// HACK: To allow thread services, we assume that the TID is equal to PID.
-		//       This is partially true, the initial TID on Linux is the same as
-		//       of the PID, and while Linux ptrace calls refer to the TID,
-		//       this holds up for the moment being, but will fall short when
-		//       multiple processes and threads come into play.
-		event.process.pid = pid;
-		event.process.state = AdbgProcessState.stopped;
+		
+		process.status |= ADBG_PROCESS_STOPPED;
+		event.process.status = process.status;
 		
 		int signo = WSTOPSIG(wstatus);
 		
-		// Get subcode and fault address if available
-		siginfo_t siginfo = void;
-		int si_code = void;
-		if (ptrace(PTRACE_GETSIGINFO, process.pid, null, &siginfo) < 0) {
-			si_code = 0;
-			event.exception.fault_address = 0;
-		} else {
-			si_code = siginfo.si_code;
-			switch (signo) { // Get fault address
-			case SIGILL, SIGSEGV, SIGFPE, SIGBUS:
-				// NOTE: .si_addr() emits linker errors on Musl platforms.
-				event.exception.fault_address =
-					cast(ulong)siginfo._sifields._sigfault.si_addr;
-				break;
-			default:
-				event.exception.fault_address = 0;
-			}
-		}
-		
-		event.exception.type = adbg_exception_from_os(signo, si_code);
-		event.exception.oscode = signo;
+		adbg_translate_exception(&event.exception, &event.process, cast(void*)signo);
 		
 		// HACK: fill up thread details for exception
 		event.exception.thread.process = &event.process;
@@ -887,7 +871,7 @@ version (Windows) {
 int adbg_debugger_terminate(adbg_process_t *process) {
 	if (process == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	if (process.creation == AdbgCreation.unloaded || process.pid == 0)
+	if ((process.status & ADBG_PROCESS_ATTACHED) == 0)
 		return adbg_oops(AdbgError.debuggerUnattached);
 	
 version (Windows) {
@@ -908,8 +892,7 @@ version (Windows) {
 		return adbg_oops(AdbgError.os);
 } else static assert(0, "Implement adbg_debugger_terminate");
 
-	process.state = AdbgProcessState.unknown;
-	process.creation = AdbgCreation.unloaded;
+	process.status = ADBG_PROCESS_EXITED; // Neither attached or stopped anyway!
 	return 0;
 }
 
@@ -921,68 +904,52 @@ version (Windows) {
 int adbg_debugger_continue(adbg_process_t *process, long tid) {
 	if (process == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	if (process.creation == AdbgCreation.unloaded)
+	
+	// Needs to be attached
+	if ((process.status & ADBG_PROCESS_ATTACHED) == 0)
 		return adbg_oops(AdbgError.debuggerUnattached);
 	
 version (Windows) {
-	version(Trace) trace("pid=%d tid=%lld state=%d", process.pid, tid, process.state);
-	switch (process.state) with (AdbgProcessState) {
+	version(Trace) trace("pid=%d tid=%lld status=%d", process.pid, tid, process.status);
 	// HACK: Created processes are not in a "stopped" state
 	//       But will continue at the next wait call
-	case created: break;
-	case stopped:
-		if (ContinueDebugEvent(process.pid, cast(DWORD)tid, DBG_CONTINUE) == FALSE) {
-			process.state = AdbgProcessState.unknown;
-			return adbg_oops(AdbgError.os);
-		}
-		break;
-	default: return adbg_oops(AdbgError.debuggerUnpaused);
+	if (ContinueDebugEvent(process.pid, cast(DWORD)tid, DBG_CONTINUE) == FALSE) {
+		process.state = AdbgProcessState.unknown;
+		return adbg_oops(AdbgError.os);
 	}
-	
-	//if (process.event_process_continued)
-	//	process.event_process_continued(process, process.udata, tid);
 } else version (linux) {
-	version(Trace) trace("pid=%d state=%d", process.pid, process.state);
-	switch (process.state) with (AdbgProcessState) {
-	case created, stopped: // attached or stopped
-		if (ptrace(PTRACE_CONT, process.pid, null, null) < 0) {
-			version (Trace) trace("ptrace=%s", strerror(errno));
-			process.state = AdbgProcessState.unknown;
-			return adbg_oops(AdbgError.os);
-		}
-		break;
-	default: return adbg_oops(AdbgError.debuggerUnpaused);
+	version(Trace) trace("pid=%d status=0x%x", process.pid, process.status);
+	if ((process.status & ADBG_PROCESS_STOPPED) == 0)
+		return adbg_oops(AdbgError.debuggerUnpaused);
+	
+	if (ptrace(PTRACE_CONT, process.pid, null, null) < 0) {
+		version (Trace) trace("ptrace=%s", strerror(errno));
+		return adbg_oops(AdbgError.os);
 	}
 } else version (Posix) {
-	version(Trace) trace("pid=%d state=%d", process.pid, process.state);
-	switch (process.state) with (AdbgProcessState) {
-	case created:
-		// TODO: Test HACK on NetBSD, OpenBSD
-		// HACK: FreeBSD: PT_TRACEME and stop state.
-		//       Because the PT_TRACEME does not seem to mark the tracee
-		//       as stopped, calling PT_CONTINUE after execve will return
-		//       errno=13 (Device Busy). raise(SIGSTOP) does nothing.
-		//       This workaround forces waiting through a stop state.
+	version(Trace) trace("pid=%d status=0x%x", process.pid, process.status);
+	// TODO: Test HACK on NetBSD, OpenBSD
+	// HACK: FreeBSD: PT_TRACEME and stop state.
+	//       Because the PT_TRACEME does not seem to mark the tracee
+	//       as stopped, calling PT_CONTINUE after execve will return
+	//       errno=13 (Device Busy). raise(SIGSTOP) does nothing.
+	//       This workaround forces waiting through a stop state.
+	if ((process.status & ADBG_PROCESS_STOPPED) == 0) {
 		int w = void;
 		waitpid(cast(pid_t)tid, &w, 0);
-		goto case;
-	case stopped:
-		// NOTE: FreeBSD/NetBSD/OpenBSD PT_CONTINUE
-		//       addr can be an address to resume at, or 1
-		//       data can be a signal number, or 0
-		if (ptrace(PT_CONTINUE, cast(pid_t)tid, cast(caddr_t)1, 0) < 0) {
-			version (Trace) trace("ptrace=%s", strerror(errno));
-			process.state = AdbgProcessState.unknown;
-			return adbg_oops(AdbgError.os);
-		}
-		if (process.event_process_continued)
-			process.event_process_continued(process, process.udata, tid);
-		break;
-	default: return adbg_oops(AdbgError.debuggerUnpaused);
+	}
+	
+	// NOTE: FreeBSD/NetBSD/OpenBSD PT_CONTINUE
+	//       addr can be an address to resume at, or 1
+	//       data can be a signal number, or 0
+	if (ptrace(PT_CONTINUE, cast(pid_t)tid, cast(caddr_t)1, 0) < 0) {
+		version (Trace) trace("ptrace=%s", strerror(errno));
+		process.state = AdbgProcessState.unknown;
+		return adbg_oops(AdbgError.os);
 	}
 } else static assert(0, "Implement adbg_debugger_continue");
 	
-	process.state = AdbgProcessState.running;
+	process.status &= ~ADBG_PROCESS_STOPPED;
 	return 0;
 }
 
@@ -996,7 +963,7 @@ version (Windows) {
 int adbg_debugger_step_instruction(adbg_process_t *process, long tid) {
 	if (process == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	if (process.creation == AdbgCreation.unloaded)
+	if ((process.status & ADBG_PROCESS_ATTACHED) == 0)
 		return adbg_oops(AdbgError.debuggerUnattached);
 	
 version (WinTel) {
@@ -1090,29 +1057,21 @@ version (WinTel) {
 	return adbg_debugger_continue(process, tid);
 } else version (linux) {
 	if (ptrace(PTRACE_SINGLESTEP, tid, null, null) < 0) {
-		process.state = AdbgProcessState.unknown;
 		return adbg_oops(AdbgError.os);
 	}
-	//if (process.event_process_continued)
-	//	process.event_process_continued(process, process.udata, tid);
 	
 	return 0;
 } else version (Posix) {
-	switch (process.state) with (AdbgProcessState) {
-	case created:
-		// HACK: See HACK in continue function.
+	// HACK: See HACK in continue function.
+	if ((process.status & ADBG_PROCESS_STOPPED) == 0) {
 		int w = void;
 		waitpid(cast(pid_t)tid, &w, 0);
-		break;
-	default:
 	}
 	
 	if (ptrace(PT_STEP, cast(pid_t)tid, null, 0) < 0) {
 		process.state = AdbgProcessState.unknown;
 		return adbg_oops(AdbgError.os);
 	}
-	if (process.event_process_continued)
-		process.event_process_continued(process, process.udata, tid);
 	
 	return 0;
 } else {

--- a/src/adbg/debugger.d
+++ b/src/adbg/debugger.d
@@ -633,11 +633,10 @@ version (Windows) {
 // NOTE: Wait function: Keep it simple!
 //
 //       The process and event parameters are absolute minimum.
-//       A timeout option is only useful on Windows.
-//       A "filter" int increases complexity pointlessly (user code can filter events itself).
-//
-//       The process return indicates which process was affected, and again,
-//       user code can filter itself.
+//       A timeout option is only useful on Windows (no timeout option for
+//       ptrace.2/wait.2 anyway).
+//       A "filter" parameter only increases complexity pointlessly (user code
+//       can filter these events itself).
 
 /// Wait until a new debug event occurs. This call is blocking.
 ///
@@ -664,6 +663,7 @@ version (Windows) {
 	DEBUG_EVENT de = void;
 Lwait:
 	if (WaitForDebugEvent(&de, process.option_timeout) == FALSE) {
+		adbg_oops(AdbgError.os);
 		return null;
 	}
 	
@@ -686,12 +686,11 @@ Lwait:
 		
 		event.process.status = process.status;
 		
-		adbg_exception_t exception = void;
-		adbg_translate_exception(&exception, process, &de);
+		adbg_translate_exception(&event.exception, process, &de);
 		// HACK: fill up thread details for exception
-		exception.thread.id      = de.dwThreadId;
-		exception.thread.process = process;
-		exception.thread.status  = 0;
+		event.exception.thread.id      = de.dwThreadId;
+		event.exception.thread.process = process;
+		event.exception.thread.status  = 0;
 		return &event.process;
 		
 		//goto Lcontinue; // auto-continue

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -213,6 +213,53 @@ int adbg_easy_continue(adbg_easy_t *ez) {
 	return adbg_easy_request(ez, &req);
 }
 
+/// Pause the process (debug break).
+///
+/// Generates a `processPaused` event. Call `adbg_easy_continue` to resume.
+/// Params: ez = Easy instance.
+/// Returns: Zero on success; Non-zero on error.
+int adbg_easy_pause(adbg_easy_t *ez) {
+	version (Trace) trace("ez=%p", ez);
+
+	if (ez == null)
+		return adbg_oops(AdbgError.invalidArgument);
+
+	adbg_easy_request_t req = adbg_easy_request_t(Request.pause);
+	return adbg_easy_request(ez, &req);
+}
+
+/// Suspend the process at OS level.
+///
+/// Call `adbg_easy_resume` to resume from a suspend.
+///
+/// Windows: Does not generate a debug event.
+/// Params: ez = Easy instance.
+/// Returns: Zero on success; Non-zero on error.
+int adbg_easy_suspend(adbg_easy_t *ez) {
+	version (Trace) trace("ez=%p", ez);
+
+	if (ez == null)
+		return adbg_oops(AdbgError.invalidArgument);
+
+	adbg_easy_request_t req = adbg_easy_request_t(Request.suspend);
+	return adbg_easy_request(ez, &req);
+}
+
+/// Resume the process from an OS-level suspend.
+///
+/// To be only used with `adbg_easy_suspend`.
+/// Params: ez = Easy instance.
+/// Returns: Zero on success; Non-zero on error.
+int adbg_easy_resume(adbg_easy_t *ez) {
+	version (Trace) trace("ez=%p", ez);
+
+	if (ez == null)
+		return adbg_oops(AdbgError.invalidArgument);
+
+	adbg_easy_request_t req = adbg_easy_request_t(Request.resume);
+	return adbg_easy_request(ez, &req);
+}
+
 /// Ask if the process is still alive.
 /// Params: ez = Easy instance.
 /// Returns: Zero on success; Non-zero on error.
@@ -272,12 +319,17 @@ enum { // Easy instance status flags
 enum Request {
 	quit       = 1,
 
+	// Debugger session creation
 	spawn      = 100,
 	attach     = 101,
 
+	// Process control
 	continue_  = 200,
 	pause      = 201,
+	suspend    = 202,
+	resume     = 203,
 
+	// Process memory
 	readmemory = 500,
 	writememory= 501,
 }
@@ -502,6 +554,22 @@ int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 		break;
 	case Request.continue_:
 		return adbg_debugger_continue(ez.process, ez.tid);
+	case Request.pause:
+		return adbg_debugger_pause(ez.process);
+	case Request.suspend:
+		int rc = adbg_debugger_suspend(ez.process);
+		if (rc) return rc;
+		// Windows: NtSuspendProcess doesn't generate debug events,
+		// synthesize a processPaused event for the event thread
+		version (Windows) {
+			adbg_event_t synth_event = void;
+			synth_event.type = AdbgEvent.processPaused;
+			synth_event.process = *ez.process;
+			adbg_mailbox_send(&ez.event_box, message_t(0, &synth_event, adbg_event_t.sizeof));
+		}
+		return 0;
+	case Request.resume:
+		return adbg_debugger_resume(ez.process);
 	default:
 		version (Trace) trace("request:unknown req.type=%d", req.type);
 		return adbg_oops(AdbgError.assertion);
@@ -577,8 +645,9 @@ Lwait:
 	if (event.type == AdbgEvent.processExit)
 		return 0;
 
-	// No event handler, auto-continue
-	if (ez.uevent == null && adbg_process_is_stopped(process))
+	// No event handler, auto-continue (but not for pause/suspend events)
+	if (ez.uevent == null && event.type != AdbgEvent.processPaused
+			&& adbg_process_is_stopped(process))
 		adbg_easy_continue(ez); // Good one...
 
 	goto Lwait;

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -72,12 +72,12 @@ adbg_easy_t* adbg_easy_create() {
 		adbg_oops(AdbgError.crt);
 		goto Lerror;
 	}
-	ez.reply_buffer = cast(adbg_easy_reply_t*)calloc(CAPACITY, adbg_easy_request_t.sizeof);
+	ez.reply_buffer = cast(adbg_easy_reply_t*)calloc(CAPACITY, adbg_easy_reply_t.sizeof);
 	if (ez.reply_buffer == null) {
 		adbg_oops(AdbgError.crt);
 		goto Lerror;
 	}
-	ez.event_buffer = cast(adbg_event_t*)calloc(CAPACITY, adbg_easy_request_t.sizeof);
+	ez.event_buffer = cast(adbg_event_t*)calloc(CAPACITY, adbg_event_t.sizeof);
 	if (ez.event_buffer == null) {
 		adbg_oops(AdbgError.crt);
 		goto Lerror;
@@ -108,9 +108,22 @@ Lerror:
 void adbg_easy_destroy(adbg_easy_t *ez) {
 	if (ez == null) return;
 
-	// TODO: Send Quit messages
-	
-	
+	// TODO: Send Quit messages to threads and wait for them to exit
+
+	if (ez.event_thread)    os_thread_join(ez.event_thread);
+	if (ez.debugger_thread) os_thread_join(ez.debugger_thread);
+
+	adbg_mailbox_destroy(&ez.request_box);
+	adbg_mailbox_destroy(&ez.reply_box);
+	adbg_mailbox_destroy(&ez.event_box);
+
+	os_mutex_destroy(&ez.lock);
+
+	if (ez.request_buffer) free(ez.request_buffer);
+	if (ez.reply_buffer)   free(ez.reply_buffer);
+	if (ez.event_buffer)   free(ez.event_buffer);
+
+	free(ez);
 }
 
 int adbg_easy_spawn(adbg_easy_t *ez, const(char) *path) {
@@ -119,9 +132,11 @@ int adbg_easy_spawn(adbg_easy_t *ez, const(char) *path) {
 	
 	os_mutex_acquire(&ez.lock);
 	
-	// 
-	if (ez.process && adbg_process_is_attached(ez.process))
+	//
+	if (ez.process && adbg_process_is_attached(ez.process)) {
+		os_mutex_release(&ez.lock);
 		return adbg_oops(AdbgError.debuggerPresent);
+	}
 	
 	// Stuff request in buffer
 	if (ez.request_count >= CAPACITY) {
@@ -162,11 +177,12 @@ int adbg_easy_spawn(adbg_easy_t *ez, const(char) *path) {
 	assert(reply, "reply==NULL");
 	if (reply.type == Reply.error) {
 		adbg_error_paste(&reply.error);
+		os_mutex_release(&ez.lock);
 		return reply.error.code;
 	}
-	
+
 	os_mutex_release(&ez.lock);
-	
+
 	return 0;
 }
 
@@ -284,26 +300,25 @@ Lwait:
 		message_t *msg = adbg_mailbox_receive(&ez.request_box);
 	if (msg) {
 		cast(void)os_mutex_acquire(&ez.lock);
-		
-		void *reply_data;
-		
+
+		// Stuff reply in buffer
+		if (ez.reply_count >= CAPACITY) {
+			assert(false); // HACK: BAD but i need to know
+		}
+
+		adbg_easy_reply_t *reply = ez.reply_buffer + ez.reply_count++;
+
 		int err = adbg_easy_handle_request(ez, msg);
 		if (err) {
-			// Stuff request in buffer
-			if (ez.reply_count >= CAPACITY) {
-				assert(false); // HACK: BAD but i need to know
-			}
-			
-			adbg_easy_reply_t *reply = ez.reply_buffer + ez.reply_count++;
 			reply.type = Reply.error;
 			adbg_error_copy(&reply.error);
-			
-			reply_data = reply;
+		} else {
+			reply.type = Reply.success;
 		}
-		
+
 		cast(void)os_mutex_release(&ez.lock);
-		
-		adbg_mailbox_send(&ez.reply_box, message_t(0, reply_data));
+
+		adbg_mailbox_send(&ez.reply_box, message_t(0, reply));
 	}
 	
 	// Windows: Poll for debugging events, and send them to event thread
@@ -325,7 +340,7 @@ Lwait:
 int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 	adbg_easy_request_t *req = cast(adbg_easy_request_t*)msg.data;
 	
-	switch (msg.type) {
+	switch (req.type) {
 	case Request.spawn:
 		adbg_process_t *proc = adbg_debugger_spawn(
 			req.spawn.path,
@@ -333,15 +348,17 @@ int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 		if (proc == null) {
 			return adbg_error_code();
 		}
-		
+
+		ez.process = proc;
+
 		version (Windows)
 			adbg_debugger_option_wait_timeout(ez.process, 100);
-		
+
 		version (Windows)
-		ez.debugger_thread =
+		ez.event_thread =
 			os_thread_new(&adbg_easy_thread_events_windows, ez);
 		version (Posix)
-		ez.debugger_thread =
+		ez.event_thread =
 			os_thread_new(&adbg_easy_thread_events_posix, ez);
 		break;
 	default:

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -278,26 +278,30 @@ Lwait:
 	if (msg) {
 		cast(void)os_mutex_acquire(&ez.lock);
 		int err = adbg_easy_handle_request(ez, msg);
-		cast(void)os_mutex_release(&ez.lock);
+		
+		void *reply_data;
 		
 		if (err) {
 			adbg_error_t *e = adbg_error();
 			
 			// Stuff request in buffer
 			if (ez.reply_count >= CAPACITY) {
-				// Can't really do anything here yet
-				// Need a mailbox function to check number of items or status (ie, full)
-				os_mutex_release(&ez.lock);
 				assert(false); // HACK: BAD but i need to know
 			}
 			
 			adbg_easy_reply_t *reply = ez.reply_buffer + ez.reply_count++;
-			import core.stdc.string : memcpy;
-			memcpy(&reply.error, e, adbg_error_t.sizeof);
+			//import core.stdc.string : memcpy;
+			//memcpy(&reply.error, e, adbg_error_t.sizeof);
+			reply.error.code = e.code;
+			reply.error.line = e.line;
+			reply.error.func = e.func;
 			
-			adbg_mailbox_send(&ez.reply_box, message_t(0, reply));
-		} else
-			adbg_mailbox_send(&ez.reply_box, message_t());
+			reply_data = reply;
+		}
+		
+		cast(void)os_mutex_release(&ez.lock);
+		
+		adbg_mailbox_send(&ez.reply_box, message_t(0, reply_data));
 	}
 	
 	// Windows: Poll for debugging events, and send them to event thread
@@ -309,7 +313,7 @@ Lwait:
 		if (process == null) // TODO: Should we error?
 			goto Lwait;
 		
-		adbg_mailbox_send(&ez.events_mbox, message_t(0, &event, adbg_event_t.sizeof));
+		adbg_mailbox_send(&ez.event_box, message_t(0, &event, adbg_event_t.sizeof));
 	}
 	goto Lwait;
 }
@@ -355,7 +359,7 @@ int adbg_easy_thread_events_windows(__osthread_t *thread, void *data) {
 	adbg_easy_t *ez = cast(adbg_easy_t*)data;
 	
 Lwait:
-	message_t *msg = adbg_mailbox_receive(&ez.events_mbox);
+	message_t *msg = adbg_mailbox_receive(&ez.event_box);
 	if (msg == null)
 		goto Lwait;
 	
@@ -365,7 +369,7 @@ Lwait:
 	
 	// If the process exits, quit loop. Nothing else to wait on
 	if (event.type == AdbgEvent.processExit)
-		return;
+		return 0;
 	goto Lwait;
 }
 

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -152,13 +152,20 @@ int adbg_easy_spawn(adbg_easy_t *ez, const(char) *path) {
 	// Get reply
 	message_t *msg = adbg_mailbox_receivefor(&ez.reply_box, 5000); // TODO: timeout option
 	if (msg == null)
-		return adbg_oops(AdbgError.assertion); // TODO: timeout error
+		return adbg_oops(AdbgError.assertion); // TODO: "operation timed out" error
+	
+	os_mutex_acquire(&ez.lock); // should replies have their own locks?
+	
+	ez.reply_count--;
 	
 	adbg_easy_reply_t *reply = cast(adbg_easy_reply_t*)msg.data;
-	if (reply) {
-		adbg_error_set2(&reply.error);
+	assert(reply, "reply==NULL");
+	if (reply.type == Reply.error) {
+		adbg_error_paste(&reply.error);
 		return reply.error.code;
 	}
+	
+	os_mutex_release(&ez.lock);
 	
 	return 0;
 }
@@ -277,24 +284,19 @@ Lwait:
 		message_t *msg = adbg_mailbox_receive(&ez.request_box);
 	if (msg) {
 		cast(void)os_mutex_acquire(&ez.lock);
-		int err = adbg_easy_handle_request(ez, msg);
 		
 		void *reply_data;
 		
+		int err = adbg_easy_handle_request(ez, msg);
 		if (err) {
-			adbg_error_t *e = adbg_error();
-			
 			// Stuff request in buffer
 			if (ez.reply_count >= CAPACITY) {
 				assert(false); // HACK: BAD but i need to know
 			}
 			
 			adbg_easy_reply_t *reply = ez.reply_buffer + ez.reply_count++;
-			//import core.stdc.string : memcpy;
-			//memcpy(&reply.error, e, adbg_error_t.sizeof);
-			reply.error.code = e.code;
-			reply.error.line = e.line;
-			reply.error.func = e.func;
+			reply.type = Reply.error;
+			adbg_error_copy(&reply.error);
 			
 			reply_data = reply;
 		}

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -6,40 +6,54 @@
 module adbg.easy;
 
 import adbg.debugger;
-import adbg.error;
+public import adbg.error;
 import adbg.os.mutex;
 import adbg.os.semaphore;
 import adbg.os.threads;
 import adbg.process.base;
-import adbg.utils.list;
 import adbg.utils.mailbox;
 import core.stdc.stdlib : calloc, free;
 
 extern (C):
 
-// Buffer entry
-private
-struct adbg_easy_request_t {
-	int id;
-	
-	union {
-	
-	} // union
-}
+// TODO: Multithread test
+//
+//       Right now, this assumes one thread caller, but real-world environments,
+//       this could be multiple callers, which will need better sync mechanics.
+//
+//       One example being if a second thread calls a request fonctions and
+//       gets the incorrect response (Request 3 finishing before Reuqest 2).
+
+/// Message capacity for mailboxes
+private enum CAPACITY = 10;
 
 /// Represents an "easy" instance.
 ///
 /// This can also be seen as a Debugger instance, too.
 struct adbg_easy_t {
-	__osthread_t   debugger_thread;
-	mailbox_t      debugger_mbox;
-	mailbox_t      replies; // OK/ERROR
-	
-	__osthread_t   events_thread;
-	mailbox_t      events_mbox;
-	list_t        *events_buffer;
-	
 	os_mutex_t     lock;
+	
+	__osthread_t *debugger_thread;
+	__osthread_t *event_thread;
+	
+	// NOTE: list_t
+	//       list_t was initially created to add non-existing items to a list
+	//       It wasn't really meant as a static buffer, so it is not used here
+	//       to hold a dynamically sized buffer of items, only fixed (at
+	//       creation time).
+	
+	mailbox_t            request_box;
+	adbg_easy_request_t *request_buffer;
+	size_t               request_count;
+	
+	mailbox_t          reply_box;
+	adbg_easy_reply_t *reply_buffer;
+	size_t             reply_count;
+	
+	mailbox_t      event_box;
+	adbg_event_t  *event_buffer;
+	
+	int status;
 	
 	adbg_process_t *process;
 }
@@ -52,20 +66,43 @@ adbg_easy_t* adbg_easy_create() {
 		return null;
 	}
 	
-	if (adbg_mailbox_create(&ez.debugger_mbox, 10) ||
-		adbg_mailbox_create(&ez.replies, 10) ||
-		adbg_mailbox_create(&ez.events_mbox, 10)) {
-		free(ez);
-		return null;
+	// Create buffers
+	ez.request_buffer = cast(adbg_easy_request_t*)calloc(CAPACITY, adbg_easy_request_t.sizeof);
+	if (ez.request_buffer == null) {
+		adbg_oops(AdbgError.crt);
+		goto Lerror;
+	}
+	ez.reply_buffer = cast(adbg_easy_reply_t*)calloc(CAPACITY, adbg_easy_request_t.sizeof);
+	if (ez.reply_buffer == null) {
+		adbg_oops(AdbgError.crt);
+		goto Lerror;
+	}
+	ez.event_buffer = cast(adbg_event_t*)calloc(CAPACITY, adbg_easy_request_t.sizeof);
+	if (ez.event_buffer == null) {
+		adbg_oops(AdbgError.crt);
+		goto Lerror;
 	}
 	
+	// Create mailboxes
+	if (adbg_mailbox_create(&ez.request_box, CAPACITY) ||
+		adbg_mailbox_create(&ez.reply_box, CAPACITY) ||
+		adbg_mailbox_create(&ez.event_box, CAPACITY)) { // error already set
+		goto Lerror;
+	}
+	
+	// 
 	if (os_mutex_init(&ez.lock)) {
 		adbg_oops(AdbgError.os);
-		free(ez);
-		return null;
+		goto Lerror;
 	}
 	
 	return ez;
+Lerror:
+	if (ez.reply_buffer)   free(ez.reply_buffer);
+	if (ez.request_buffer) free(ez.request_buffer);
+	if (ez.event_buffer)   free(ez.event_buffer);
+	free(ez);
+	return null;
 }
 
 void adbg_easy_destroy(adbg_easy_t *ez) {
@@ -80,17 +117,48 @@ int adbg_easy_spawn(adbg_easy_t *ez, const(char) *path) {
 	if (ez == null)
 		return adbg_oops(AdbgError.invalidArgument);
 	
-	int rc = adbg_mailbox_send(&ez.debugger_mbox,
-		message_t(Request.spawn, cast(void*)path, 0));
+	os_mutex_acquire(&ez.lock);
+	
+	// 
+	if (ez.process && adbg_process_is_attached(ez.process))
+		return adbg_oops(AdbgError.debuggerPresent);
+	
+	// Stuff request in buffer
+	if (ez.request_count >= CAPACITY) {
+		// Can't really do anything here yet
+		// Need a mailbox function to check number of items or status (ie, full)
+		os_mutex_release(&ez.lock);
+		return adbg_oops(AdbgError.assertion);
+	}
+	
+	adbg_easy_request_t *req = ez.request_buffer + ez.request_count++;
+	req.type = Request.spawn;
+	req.spawn.path = path;
+	os_mutex_release(&ez.lock);
+	
+	// If the debugger thread hasn't started, start it
+	if (ez.debugger_thread == null) {
+		ez.debugger_thread = os_thread_new(&adbg_easy_thread_debugger, ez);
+		if (ez.debugger_thread == null) {
+			--ez.request_count;
+			return adbg_oops(AdbgError.os);
+		}
+	}
+	
+	// Send it
+	int rc = adbg_mailbox_send(&ez.request_box, message_t(0, req, 0));
 	if (rc) return rc;
 	
-	message_t *msg = adbg_mailbox_receivefor(&ez.replies, 5000); // TODO: timeout option
+	// Get reply
+	message_t *msg = adbg_mailbox_receivefor(&ez.reply_box, 5000); // TODO: timeout option
 	if (msg == null)
 		return adbg_oops(AdbgError.assertion); // TODO: timeout error
 	
-	// Set error on this thread since error stuff is TLS now
-	if (msg.type)
-		return adbg_oops(cast(AdbgError)msg.type);
+	adbg_easy_reply_t *reply = cast(adbg_easy_reply_t*)msg.data;
+	if (reply) {
+		adbg_error_set2(&reply.error);
+		return reply.error.code;
+	}
 	
 	return 0;
 }
@@ -137,6 +205,19 @@ int adbg_easy_attach(adbg_easy_t *ez, int pid) {
 
 private:
 
+enum {
+	/// Debugger is attached.
+	EASY_ATTACHED = 1,
+	/// Process has stopped.
+	EASY_STOPPED  = 1 << 1,
+	/// Process has exited.
+	EASY_EXITED   = 1 << 2,
+}
+
+//
+// Requests
+//
+
 enum Request {
 	quit       = 1,
 	
@@ -150,17 +231,40 @@ enum Request {
 	writememory= 501,
 }
 
-struct request_spawn_t {
-	char *path;
+struct adbg_easy_request_spawn_t {
+	const(char) *path;
 }
 
-enum REPLY_OK  = 0;
+// Buffer entry
+struct adbg_easy_request_t {
+	Request type;
+	union {
+	adbg_easy_request_spawn_t spawn;
+	} // union
+}
+
+//
+// Replies/Responses
+//
+
+enum Reply {
+	success,
+	error,
+}
+
+// 
+struct adbg_easy_reply_t {
+	Reply type;
+	union {
+	adbg_error_t error;
+	}
+}
 
 //
 // Easy API: Debug loop
 //
 
-void adbg_easy_thread_debugger(void *data) {
+int adbg_easy_thread_debugger(__osthread_t *thread, void *data) {
 	assert(data);
 	adbg_easy_t *ez = cast(adbg_easy_t*)data;
 	
@@ -168,30 +272,44 @@ void adbg_easy_thread_debugger(void *data) {
 Lwait:
 	// Wait for a request
 	version (Windows)
-		message_t *msg = adbg_mailbox_receivefor(&ez.debugger_mbox, timeout_ms);
+		message_t *msg = adbg_mailbox_receivefor(&ez.request_box, timeout_ms);
 	else
-		message_t *msg = adbg_mailbox_receive(&ez.debugger_mbox);
+		message_t *msg = adbg_mailbox_receive(&ez.request_box);
 	if (msg) {
 		cast(void)os_mutex_acquire(&ez.lock);
 		int err = adbg_easy_handle_request(ez, msg);
 		cast(void)os_mutex_release(&ez.lock);
-		if (err)
-			adbg_mailbox_send(&ez.replies, message_t(err));
-		else
-			adbg_mailbox_send(&ez.replies, message_t(REPLY_OK));
+		
+		if (err) {
+			adbg_error_t *e = adbg_error();
+			
+			// Stuff request in buffer
+			if (ez.reply_count >= CAPACITY) {
+				// Can't really do anything here yet
+				// Need a mailbox function to check number of items or status (ie, full)
+				os_mutex_release(&ez.lock);
+				assert(false); // HACK: BAD but i need to know
+			}
+			
+			adbg_easy_reply_t *reply = ez.reply_buffer + ez.reply_count++;
+			import core.stdc.string : memcpy;
+			memcpy(&reply.error, e, adbg_error_t.sizeof);
+			
+			adbg_mailbox_send(&ez.reply_box, message_t(0, reply));
+		} else
+			adbg_mailbox_send(&ez.reply_box, message_t());
 	}
 	
-	// Check for debugging events, and send them to event thread
+	// Windows: Poll for debugging events, and send them to event thread
 	// TODO: Check if process attached, not if exists
 	version (Windows)
 	if (ez.process) {
 		adbg_event_t event = void;
 		adbg_process_t *process = adbg_debugger_wait(ez.process, &event);
-		if (process == null) {
+		if (process == null) // TODO: Should we error?
 			goto Lwait;
-		}
 		
-		
+		adbg_mailbox_send(&ez.events_mbox, message_t(0, &event, adbg_event_t.sizeof));
 	}
 	goto Lwait;
 }
@@ -199,18 +317,26 @@ Lwait:
 // Just handle the request here, the caller (debugger thread) handles
 // sending the message back to the caller
 int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
+	adbg_easy_request_t *req = cast(adbg_easy_request_t*)msg.data;
+	
 	switch (msg.type) {
 	case Request.spawn:
-		request_spawn_t *req = cast(request_spawn_t*)msg.data;
-		
 		adbg_process_t *proc = adbg_debugger_spawn(
-			req.path,
+			req.spawn.path,
 			0);
 		if (proc == null) {
 			return adbg_error_code();
 		}
 		
-		adbg_debugger_option_wait_timeout(ez.process, 100);
+		version (Windows)
+			adbg_debugger_option_wait_timeout(ez.process, 100);
+		
+		version (Windows)
+		ez.debugger_thread =
+			os_thread_new(&adbg_easy_thread_events_windows, ez);
+		version (Posix)
+		ez.debugger_thread =
+			os_thread_new(&adbg_easy_thread_events_posix, ez);
 		break;
 	default:
 		return adbg_oops(AdbgError.assertion);
@@ -224,7 +350,7 @@ int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 
 // Easy API event handler thread
 version (Windows)
-void adbg_easy_thread_events_windows(void *data) {
+int adbg_easy_thread_events_windows(__osthread_t *thread, void *data) {
 	assert(data);
 	adbg_easy_t *ez = cast(adbg_easy_t*)data;
 	
@@ -244,7 +370,7 @@ Lwait:
 }
 
 version (Posix)
-void adbg_easy_thread_events_posix(void *data) {
+int adbg_easy_thread_events_posix(__osthread_t *thread, void *data) {
 	assert(data);
 	adbg_easy_t *ez = cast(adbg_easy_t*)data;
 	
@@ -252,12 +378,12 @@ void adbg_easy_thread_events_posix(void *data) {
 Lwait:
 	adbg_process_t *process = adbg_debugger_wait(ez.process, &event);
 	if (process == null)
-		return;
+		return adbg_error_code();
 	
 	// TODO: Send event to user callback
 	
 	// If the process exits, quit loop. Nothing else to wait on
 	if (event.type == AdbgEvent.processExit)
-		return;
+		return 0;
 	goto Lwait;
 }

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -42,12 +42,9 @@ struct adbg_easy_t {
 	//       creation time).
 	
 	mailbox_t            request_box;
-	adbg_easy_request_t *request_buffer;
-	size_t               request_count;
-	
+
 	mailbox_t          reply_box;
-	adbg_easy_reply_t *reply_buffer;
-	size_t             reply_count;
+	adbg_easy_reply_t  reply;
 	
 	mailbox_t      event_box;
 	adbg_event_t  *event_buffer;
@@ -66,16 +63,6 @@ adbg_easy_t* adbg_easy_create() {
 	}
 	
 	// Create buffers
-	ez.request_buffer = cast(adbg_easy_request_t*)calloc(CAPACITY, adbg_easy_request_t.sizeof);
-	if (ez.request_buffer == null) {
-		adbg_oops(AdbgError.crt);
-		goto Lerror;
-	}
-	ez.reply_buffer = cast(adbg_easy_reply_t*)calloc(CAPACITY, adbg_easy_reply_t.sizeof);
-	if (ez.reply_buffer == null) {
-		adbg_oops(AdbgError.crt);
-		goto Lerror;
-	}
 	ez.event_buffer = cast(adbg_event_t*)calloc(CAPACITY, adbg_event_t.sizeof);
 	if (ez.event_buffer == null) {
 		adbg_oops(AdbgError.crt);
@@ -89,16 +76,21 @@ adbg_easy_t* adbg_easy_create() {
 		goto Lerror;
 	}
 	
-	// 
+	//
 	if (os_mutex_init(&ez.lock)) {
 		adbg_oops(AdbgError.os);
 		goto Lerror;
 	}
-	
+
+	// Start debugger thread (blocks waiting for requests)
+	ez.debugger_thread = os_thread_new(&adbg_easy_thread_debugger, ez);
+	if (ez.debugger_thread == null) {
+		adbg_oops(AdbgError.os);
+		goto Lerror;
+	}
+
 	return ez;
 Lerror:
-	if (ez.reply_buffer)   free(ez.reply_buffer);
-	if (ez.request_buffer) free(ez.request_buffer);
 	if (ez.event_buffer)   free(ez.event_buffer);
 	free(ez);
 	return null;
@@ -118,8 +110,6 @@ void adbg_easy_destroy(adbg_easy_t *ez) {
 
 	os_mutex_destroy(&ez.lock);
 
-	if (ez.request_buffer) free(ez.request_buffer);
-	if (ez.reply_buffer)   free(ez.reply_buffer);
 	if (ez.event_buffer)   free(ez.event_buffer);
 
 	free(ez);
@@ -128,61 +118,11 @@ void adbg_easy_destroy(adbg_easy_t *ez) {
 int adbg_easy_spawn(adbg_easy_t *ez, const(char) *path) {
 	if (ez == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	
-	os_mutex_acquire(&ez.lock);
-	
-	//
-	if (ez.process && adbg_process_is_attached(ez.process)) {
-		os_mutex_release(&ez.lock);
-		return adbg_oops(AdbgError.debuggerPresent);
-	}
-	
-	// Stuff request in buffer
-	if (ez.request_count >= CAPACITY) {
-		// Can't really do anything here yet
-		// Need a mailbox function to check number of items or status (ie, full)
-		os_mutex_release(&ez.lock);
-		return adbg_oops(AdbgError.assertion);
-	}
-	
-	adbg_easy_request_t *req = ez.request_buffer + ez.request_count++;
+
+	adbg_easy_request_t req;
 	req.type = Request.spawn;
 	req.spawn.path = path;
-	os_mutex_release(&ez.lock);
-	
-	// If the debugger thread hasn't started, start it
-	if (ez.debugger_thread == null) {
-		ez.debugger_thread = os_thread_new(&adbg_easy_thread_debugger, ez);
-		if (ez.debugger_thread == null) {
-			--ez.request_count;
-			return adbg_oops(AdbgError.os);
-		}
-	}
-	
-	// Send it
-	int rc = adbg_mailbox_send(&ez.request_box, message_t(0, req, 0));
-	if (rc) return rc;
-	
-	// Get reply
-	message_t *msg = adbg_mailbox_receivefor(&ez.reply_box, 5000); // TODO: timeout option
-	if (msg == null)
-		return adbg_oops(AdbgError.assertion); // TODO: "operation timed out" error
-	
-	os_mutex_acquire(&ez.lock); // should replies have their own locks?
-	
-	ez.reply_count--;
-	
-	adbg_easy_reply_t *reply = cast(adbg_easy_reply_t*)msg.data;
-	assert(reply, "reply==NULL");
-	if (reply.type == Reply.error) {
-		adbg_error_paste(&reply.error);
-		os_mutex_release(&ez.lock);
-		return reply.error.code;
-	}
-
-	os_mutex_release(&ez.lock);
-
-	return 0;
+	return adbg_easy_request(ez, &req);
 }
 
 int adbg_easy_attach(adbg_easy_t *ez, int pid) {
@@ -283,6 +223,37 @@ struct adbg_easy_reply_t {
 }
 
 //
+// Easy API: Request helper
+//
+
+/// Send a request to the debugger thread and wait for a reply.
+/// Optionally returns the reply pointer for callers that need response data.
+int adbg_easy_request(adbg_easy_t *ez, adbg_easy_request_t *req,
+		adbg_easy_reply_t **reply_out = null) {
+	// Send request (mailbox handles blocking if full)
+	int rc = adbg_mailbox_send(&ez.request_box, message_t(0, req, 0));
+	if (rc) return rc;
+
+	// Wait for reply // TODO: timeout option
+	message_t *msg = adbg_mailbox_receivefor(&ez.reply_box, 5000);
+	if (msg == null)
+		return adbg_oops(AdbgError.assertion); // TODO: "operation timed out" error
+
+	adbg_easy_reply_t *reply = cast(adbg_easy_reply_t*)msg.data;
+	assert(reply, "reply==NULL");
+
+	if (reply_out)
+		*reply_out = reply;
+
+	if (reply.type == Reply.error) {
+		adbg_error_paste(&reply.error);
+		return reply.error.code;
+	}
+
+	return 0;
+}
+
+//
 // Easy API: Debug loop
 //
 
@@ -298,26 +269,15 @@ Lwait:
 	else
 		message_t *msg = adbg_mailbox_receive(&ez.request_box);
 	if (msg) {
-		cast(void)os_mutex_acquire(&ez.lock);
-
-		// Stuff reply in buffer
-		if (ez.reply_count >= CAPACITY) {
-			assert(false); // HACK: BAD but i need to know
-		}
-
-		adbg_easy_reply_t *reply = ez.reply_buffer + ez.reply_count++;
-
 		int err = adbg_easy_handle_request(ez, msg);
 		if (err) {
-			reply.type = Reply.error;
-			adbg_error_copy(&reply.error);
+			ez.reply.type = Reply.error;
+			adbg_error_copy(&ez.reply.error);
 		} else {
-			reply.type = Reply.success;
+			ez.reply.type = Reply.success;
 		}
 
-		cast(void)os_mutex_release(&ez.lock);
-
-		adbg_mailbox_send(&ez.reply_box, message_t(0, reply));
+		adbg_mailbox_send(&ez.reply_box, message_t(0, &ez.reply));
 	}
 	
 	// Windows: Poll for debugging events, and send them to event thread
@@ -341,6 +301,9 @@ int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 	
 	switch (req.type) {
 	case Request.spawn:
+		if (ez.process && adbg_process_is_attached(ez.process))
+			return adbg_oops(AdbgError.debuggerPresent);
+
 		adbg_process_t *proc = adbg_debugger_spawn(
 			req.spawn.path,
 			0);

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -1,12 +1,15 @@
-/// 
+/// Easy API implementation.
+///
+/// While an Easy instance can only support a single process, multiple Easy
+/// instances can be created.
 ///
 /// Authors: dd86k <dd@dax.moe>
 /// Copyright: © dd86k <dd@dax.moe>
 /// License: BSD-3-Clause-Clear
 module adbg.easy;
 
+public import adbg.error; // makes it easier to deal with messages
 import adbg.debugger;
-public import adbg.error;
 import adbg.os.mutex;
 import adbg.os.threads;
 import adbg.process.base;
@@ -29,55 +32,58 @@ private enum CAPACITY = 10;
 /// Represents an Easy instance.
 struct adbg_easy_t {
 	os_mutex_t     lock;
-	
+
 	__osthread_t *debugger_thread;
 	__osthread_t *event_thread;
-	
+
 	// NOTE: list_t
 	//       list_t was initially created to add non-existing items to a list
 	//       It wasn't really meant as a static buffer, so it is not used here
 	//       to hold a dynamically sized buffer of items, only fixed (at
 	//       creation time).
-	
+
 	mailbox_t          request_box;
 
 	mailbox_t          reply_box;
 	adbg_easy_reply_t  reply;
-	
+
 	mailbox_t      event_box;
-	adbg_event_t  *event_buffer;
 
 	adbg_process_t *process;
+	void *udata;
+
+	// There is only one callback, because, just like the note in src/adbg/debugger.d,
+	// there is no point doing filtering ourselves.
+	void function(adbg_process_t *process, adbg_event_t *event, void *udata) uevent;
 	
-	// TODO: Event callbacks here
+	// Last event Thread ID.
+	// A hack for auto-continue because code structure is not great...
+	long tid;
 }
+
+//
+// Easy API management (create & destroy)
+//
 
 /// Create a new Easy instance for use with the Easy API.
 /// Returns: Easy instance; Or null on error.
 adbg_easy_t* adbg_easy_create() {
 	version (Trace) trace("adbg_easy_t.sizeof=%d", cast(int)adbg_easy_t.sizeof);
-	
-	// 
+
+	// Create instance and buffers
 	adbg_easy_t *ez = cast(adbg_easy_t*)calloc(1, adbg_easy_t.sizeof);
 	if (ez == null) {
 		adbg_oops(AdbgError.crt);
 		return null;
 	}
-	
-	// Create buffers
-	ez.event_buffer = cast(adbg_event_t*)calloc(CAPACITY, adbg_event_t.sizeof);
-	if (ez.event_buffer == null) {
-		adbg_oops(AdbgError.crt);
-		goto Lerror;
-	}
-	
+
 	// Create mailboxes
 	if (adbg_mailbox_create(&ez.request_box, CAPACITY) ||
 		adbg_mailbox_create(&ez.reply_box, CAPACITY) ||
 		adbg_mailbox_create(&ez.event_box, CAPACITY)) { // error already set
 		goto Lerror;
 	}
-	
+
 	//
 	if (os_mutex_init(&ez.lock)) {
 		adbg_oops(AdbgError.os);
@@ -93,7 +99,6 @@ adbg_easy_t* adbg_easy_create() {
 
 	return ez;
 Lerror:
-	if (ez.event_buffer)   free(ez.event_buffer);
 	free(ez);
 	return null;
 }
@@ -105,14 +110,14 @@ Lerror:
 /// Params: ez = Easy instance.
 void adbg_easy_destroy(adbg_easy_t *ez) {
 	version (Trace) trace("ez=%p", ez);
-	
+
 	if (ez == null) return;
-	
+
 	// Windows need to terminate process in debugger thread
 	adbg_easy_request_t req = adbg_easy_request_t(Request.quit);
 	if (adbg_easy_request(ez, &req))
 		return; // error, so can't continue cleanup, fuck!
-	
+
 	//adbg_mailbox_send(&ez.request_box, message_t(0, &quit_req, 0));
 	if (ez.debugger_thread) os_thread_join(ez.debugger_thread); // cleanup
 	if (ez.event_thread)    os_thread_join(ez.event_thread);    // cleanup
@@ -124,10 +129,42 @@ void adbg_easy_destroy(adbg_easy_t *ez) {
 	adbg_mailbox_destroy(&ez.event_box);
 	os_mutex_destroy(&ez.lock);
 
-	if (ez.event_buffer)   free(ez.event_buffer);
-
 	free(ez);
 }
+
+/// Attach an event handler to the Easy instance.
+///
+/// When there are no event handlers, the debugger will automatically continue
+/// on exceptions.
+/// Params:
+/// 	ez = Easy instance.
+/// 	ufunc = User function. Can be set to null to clear it.
+void adbg_easy_set_event_handler(adbg_easy_t *ez,
+	void function(adbg_process_t *process, adbg_event_t *event, void *udata) ufunc) {
+	version (Trace) trace("ez=%p ufunc=%p", ez, ufunc);
+
+	if (ez == null)
+		return;
+
+	ez.uevent = ufunc;
+}
+
+/// Attach user data to Easy instance that will be used in event callbacks.
+/// Params:
+/// 	ez = Easy instance.
+/// 	udata = User data pointer. Can be set to null to clear it.
+void adbg_easy_set_user_data(adbg_easy_t *ez, void *udata) {
+	version (Trace) trace("ez=%p udata=%p", ez, udata);
+
+	if (ez == null)
+		return;
+
+	ez.udata = udata;
+}
+
+//
+// Easy API requests (spawn, attach, continue, etc.)
+//
 
 /// Spawn a new process to be tracked by the debugger.
 /// Params:
@@ -136,7 +173,7 @@ void adbg_easy_destroy(adbg_easy_t *ez) {
 /// Returns: Zero on success; Non-zero on error.
 int adbg_easy_spawn(adbg_easy_t *ez, const(char) *path) {
 	version (Trace) trace("ez=%p path=%p", ez, path);
-	
+
 	if (ez == null)
 		return adbg_oops(AdbgError.invalidArgument);
 
@@ -153,13 +190,26 @@ int adbg_easy_spawn(adbg_easy_t *ez, const(char) *path) {
 /// Returns: Zero on success; Non-zero on error.
 int adbg_easy_attach(adbg_easy_t *ez, int pid) {
 	version (Trace) trace("ez=%p pid=%d", ez, pid);
-	
+
 	if (ez == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	
+
 	adbg_easy_request_t req = void;
 	req.type = Request.attach;
 	req.attach.pid = pid;
+	return adbg_easy_request(ez, &req);
+}
+
+/// Continue the process from a previous signaled stopped state (event).
+/// Params: ez = Easy instance.
+/// Returns: Zero on success; Non-zero on error.
+int adbg_easy_continue(adbg_easy_t *ez) {
+	version (Trace) trace("ez=%p", ez);
+
+	if (ez == null)
+		return adbg_oops(AdbgError.invalidArgument);
+
+	adbg_easy_request_t req = adbg_easy_request_t(Request.continue_);
 	return adbg_easy_request(ez, &req);
 }
 
@@ -168,7 +218,7 @@ int adbg_easy_attach(adbg_easy_t *ez, int pid) {
 /// Returns: Zero on success; Non-zero on error.
 int adbg_easy_process_is_alive(adbg_easy_t *ez) {
 	version (Trace) trace("ez=%p", ez);
-	
+
 	if (ez == null || ez.process == null)
 		return adbg_oops(AdbgError.invalidArgument);
 	return adbg_process_is_alive(ez.process);
@@ -189,17 +239,17 @@ private:
 
   Windows model
   Debug API & WaitForDebugEvent functions MUST be on the same thread
-  
+
   User Thread
     [Request Mailbox]
       Debugger Thread + Event polling
         On Attach/Spawn: Spawn event thread
         On Event: [Event Mailbox] -> Event Thread -> User Callback
-  
+
   POSIX model
   On Linux, ptrace.2 & wait.2 can be called from different threads
   Don't know for BSDs at the moment
-  
+
   User Thread
     [Request Mailbox]
       Debugger Thread
@@ -221,13 +271,13 @@ enum { // Easy instance status flags
 
 enum Request {
 	quit       = 1,
-	
+
 	spawn      = 100,
 	attach     = 101,
-	
+
 	continue_  = 200,
 	pause      = 201,
-	
+
 	readmemory = 500,
 	writememory= 501,
 }
@@ -304,15 +354,25 @@ int adbg_easy_request(adbg_easy_t *ez, adbg_easy_request_t *req,
 }
 
 //
-// Easy API: Debug loop
+// Debugger thread
 //
 
 enum EVENT_MSG_QUIT = 1;
 
+// Internal function to know if debugger should auto-continue.
+// Called by debugger thread on Windows and event thread on POSIX.
+// Returns positive value if callback for event is unset AND process is stopped.
+int adbg_easy_should_auto_continue_(adbg_easy_t *ez, adbg_process_t *process, adbg_event_t *event) {
+	assert(ez, "adbg_easy_should_auto_continue_::ez==NULL");
+	assert(process, "adbg_easy_should_auto_continue_::process==NULL");
+	assert(event, "adbg_easy_should_auto_continue_::event==NULL");
+	return adbg_process_is_stopped(process) && ez.uevent == null;
+}
+
 int adbg_easy_thread_debugger(__osthread_t *thread, void *data) {
 	assert(data);
 	adbg_easy_t *ez = cast(adbg_easy_t*)data;
-	
+
 	version (Windows) uint timeout_ms = 100;
 Lwait:
 	// Wait for a request
@@ -340,7 +400,7 @@ Lwait:
 
 		adbg_mailbox_send(&ez.reply_box, message_t(0, &ez.reply));
 	}
-	
+
 	// Windows: Poll for debugging events, and send them to event thread
 	// TODO: Check if process is attached
 	//       Would make more sense, but it is an more expensive call to do in a loop
@@ -348,30 +408,31 @@ Lwait:
 	if (ez.process) {
 		adbg_event_t event = void;
 		adbg_process_t *process = adbg_debugger_wait(ez.process, &event);
-		if (process == null) // TODO: Should we error?
+		if (process == null) // TODO: Should we report this error?
 			goto Lwait;
-		
-		adbg_mailbox_send(&ez.event_box, message_t(0, &event, adbg_event_t.sizeof));
 
-		// HACK: Continue so next WaitForDebugEvent doesn't block
-		if (event.type == AdbgEvent.exception)
-			adbg_debugger_continue(ez.process, event.exception.thread.id);
+		ez.tid = event.exception.thread.id; // for auto-continue
+
+		// Stopped and no event handler set? Continue and don't message
+		if (adbg_easy_should_auto_continue_(ez, process, &event))
+			adbg_debugger_continue(process, event.exception.thread.id);
+		else
+			adbg_mailbox_send(&ez.event_box, message_t(0, &event, adbg_event_t.sizeof));
 	}
 	goto Lwait;
 }
 
-// Just handle the request here, the caller (debugger thread) handles
-// sending the message back to the caller
+// Handles debugger request. Called by debugger thread to make it cleaner.
 int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 	adbg_easy_request_t *req = cast(adbg_easy_request_t*)msg.data;
-	
+
 	version (Trace) trace("ez=%p msg=%p req=%p", ez, msg, req);
-	
+
 	version (Windows) uint timeout_ms = 100; // default timeout
 	switch (req.type) {
 	case Request.spawn:
 		version (Trace) trace("request:spawn path=%p", req.spawn.path);
-		
+
 		if (ez.process && adbg_process_is_attached(ez.process))
 			return adbg_oops(AdbgError.debuggerPresent);
 
@@ -397,10 +458,10 @@ int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 		break;
 	case Request.attach:
 		version (Trace) trace("request:spawn pid=%p", req.attach.pid);
-		
+
 		if (ez.process && adbg_process_is_attached(ez.process))
 			return adbg_oops(AdbgError.debuggerPresent);
-		
+
 		ez.process = adbg_debugger_attach(req.attach.pid, 0);
 		if (ez.process == null)
 			return adbg_error_code();
@@ -408,7 +469,7 @@ int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 		// Hack to make multi-threaded events work
 		version (Windows)
 			adbg_debugger_option_wait_timeout(ez.process, timeout_ms);
-		
+
 		// Make event thread
 		version (Windows)
 			ez.event_thread = os_thread_new(&adbg_easy_thread_events_windows, ez);
@@ -419,7 +480,8 @@ int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 		break;
 	case Request.quit:
 		version (Trace) trace("request:quit");
-		
+
+		// TODO: If spawned and running, maybe consider pausing it before terminating!
 		// Signal threads to exit and wait for them to finish
 		//
 		// Terminate/detach first to unblock event threads:
@@ -438,6 +500,8 @@ int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 				return attached;
 		}
 		break;
+	case Request.continue_:
+		return adbg_debugger_continue(ez.process, ez.tid);
 	default:
 		version (Trace) trace("request:unknown req.type=%d", req.type);
 		return adbg_oops(AdbgError.assertion);
@@ -446,12 +510,8 @@ int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 }
 
 //
-// Event loops
+// Event thread
 //
-
-// Called from Event thread (adbg_easy_thread_events_windows or adbg_easy_thread_events_posix)
-// 
-//void adbg_easy_send_event(
 
 // Windows event thread
 //
@@ -465,24 +525,23 @@ int adbg_easy_thread_events_windows(__osthread_t *thread, void *data) {
 
 Lwait:
 	message_t *msg = adbg_mailbox_receive(&ez.event_box);
-	// HACK: msg.type==1 is sent by debugger thread when quitting
+	// HACK: EVENT_MSG_QUIT is sent by debugger thread when quitting
+	//       without notifying user callback
 	if (msg == null || msg.type == EVENT_MSG_QUIT)
 		return 0;
 
-	// TODO: Send event to user callback
 	adbg_event_t *event = cast(adbg_event_t*)msg.data;
-	adbg_process_t *process = &event.process;
 
-	switch (event.type) {
-	case AdbgEvent.exception:
-		// TODO: if event callback set, call it
-		break;
-	// If the process exits, quit loop. Nothing else to wait on
-	case AdbgEvent.processExit:
-		return 0;
-	default:
-		version (Trace) trace("not implemented: %d", event.type);
+	// Send event to user callback
+	if (ez.uevent) {
+		adbg_process_t *process = &event.process;
+		ez.uevent(process, event, ez.udata);
 	}
+
+	// If the process exits, quit loop. Nothing else to wait on
+	if (event.type == AdbgEvent.processExit)
+		return 0;
+
 	goto Lwait;
 }
 
@@ -499,26 +558,28 @@ version (Posix)
 int adbg_easy_thread_events_posix(__osthread_t *thread, void *data) {
 	assert(data);
 	adbg_easy_t *ez = cast(adbg_easy_t*)data;
-	
-	// NOTE: When terminating, the detach/exit event makes this thread quit
+
+	// NOTE: When terminating, the detach/exit event signals this thread
 	adbg_event_t event = void;
 Lwait:
 	adbg_process_t *process = adbg_debugger_wait(ez.process, &event);
 	if (process == null)
 		return adbg_error_code();
-	
-	// TODO: Send event to user callback
-	
-	switch (event.type) {
-	case AdbgEvent.exception:
-		// TODO: if event callback set, call it
-		adbg_debugger_continue(ez.process, event.exception.thread.id);
-		break;
+
+	if (event.type == AdbgEvent.exception)
+		ez.tid = event.exception.thread.id; // for auto-continue
+
+	// Send event to user callback
+	if (ez.uevent)
+		ez.uevent(process, &event, ez.udata);
+
 	// If the process exits, quit loop. Nothing else to wait on
-	case AdbgEvent.processExit:
+	if (event.type == AdbgEvent.processExit)
 		return 0;
-	default:
-		version (Trace) trace("not implemented: %d", event.type);
-	}
+
+	// No event handler, auto-continue
+	if (ez.uevent == null && adbg_process_is_stopped(process))
+		adbg_easy_continue(ez); // Good one...
+
 	goto Lwait;
 }

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -26,9 +26,7 @@ extern (C):
 /// Message capacity for mailboxes
 private enum CAPACITY = 10;
 
-/// Represents an "easy" instance.
-///
-/// This can also be seen as a Debugger instance, too.
+/// Represents an Easy instance.
 struct adbg_easy_t {
 	os_mutex_t     lock;
 	
@@ -41,20 +39,24 @@ struct adbg_easy_t {
 	//       to hold a dynamically sized buffer of items, only fixed (at
 	//       creation time).
 	
-	mailbox_t            request_box;
+	mailbox_t          request_box;
 
 	mailbox_t          reply_box;
 	adbg_easy_reply_t  reply;
 	
 	mailbox_t      event_box;
 	adbg_event_t  *event_buffer;
-	
-	int status;
-	
+
 	adbg_process_t *process;
+	
+	// TODO: Event callbacks here
 }
 
+/// Create a new Easy instance for use with the Easy API.
+/// Returns: Easy instance; Or null on error.
 adbg_easy_t* adbg_easy_create() {
+	version (Trace) trace("adbg_easy_t.sizeof=%d", cast(int)adbg_easy_t.sizeof);
+	
 	// 
 	adbg_easy_t *ez = cast(adbg_easy_t*)calloc(1, adbg_easy_t.sizeof);
 	if (ez == null) {
@@ -96,18 +98,30 @@ Lerror:
 	return null;
 }
 
+/// Destroy the Easy instance.
+///
+/// If the target process was spawned, it is terminated.
+/// If the target process was attached, the debugger detaches.
+/// Params: ez = Easy instance.
 void adbg_easy_destroy(adbg_easy_t *ez) {
+	version (Trace) trace("ez=%p", ez);
+	
 	if (ez == null) return;
+	
+	// Windows need to terminate process in debugger thread
+	adbg_easy_request_t req = adbg_easy_request_t(Request.quit);
+	if (adbg_easy_request(ez, &req))
+		return; // error, so can't continue cleanup, fuck!
+	
+	//adbg_mailbox_send(&ez.request_box, message_t(0, &quit_req, 0));
+	if (ez.debugger_thread) os_thread_join(ez.debugger_thread); // cleanup
+	if (ez.event_thread)    os_thread_join(ez.event_thread);    // cleanup
 
-	// TODO: Send Quit messages to threads and wait for them to exit
-
-	if (ez.event_thread)    os_thread_join(ez.event_thread);
-	if (ez.debugger_thread) os_thread_join(ez.debugger_thread);
-
+	// Threads are gone, time to clean up
+	if (ez.process) adbg_process_free(ez.process);
 	adbg_mailbox_destroy(&ez.request_box);
 	adbg_mailbox_destroy(&ez.reply_box);
 	adbg_mailbox_destroy(&ez.event_box);
-
 	os_mutex_destroy(&ez.lock);
 
 	if (ez.event_buffer)   free(ez.event_buffer);
@@ -115,71 +129,90 @@ void adbg_easy_destroy(adbg_easy_t *ez) {
 	free(ez);
 }
 
+/// Spawn a new process to be tracked by the debugger.
+/// Params:
+/// 	ez = Easy instance.
+/// 	path = Null-terminated path pointer.
+/// Returns: Zero on success; Non-zero on error.
 int adbg_easy_spawn(adbg_easy_t *ez, const(char) *path) {
+	version (Trace) trace("ez=%p path=%p", ez, path);
+	
 	if (ez == null)
 		return adbg_oops(AdbgError.invalidArgument);
 
-	adbg_easy_request_t req;
+	adbg_easy_request_t req = void;
 	req.type = Request.spawn;
 	req.spawn.path = path;
 	return adbg_easy_request(ez, &req);
 }
 
+/// Attaches to an existing process to be tracked by the debugger.
+/// Params:
+/// 	ez = Easy instance.
+/// 	pid = Process ID.
+/// Returns: Zero on success; Non-zero on error.
 int adbg_easy_attach(adbg_easy_t *ez, int pid) {
+	version (Trace) trace("ez=%p pid=%d", ez, pid);
+	
 	if (ez == null)
 		return adbg_oops(AdbgError.invalidArgument);
 	
-	adbg_easy_request_t req;
+	adbg_easy_request_t req = void;
 	req.type = Request.attach;
 	req.attach.pid = pid;
 	return adbg_easy_request(ez, &req);
 }
 
-// NOTE: adbg_debugger_on_* advantages over adbg_debugger_on(enum)
+/// Ask if the process is still alive.
+/// Params: ez = Easy instance.
+/// Returns: Zero on success; Non-zero on error.
+int adbg_easy_process_is_alive(adbg_easy_t *ez) {
+	version (Trace) trace("ez=%p", ez);
+	
+	if (ez == null || ez.process == null)
+		return adbg_oops(AdbgError.invalidArgument);
+	return adbg_process_is_alive(ez.process);
+}
+
+// NOTE: Debugger events
+//       Because this is multithreaded, obviously, callbacks are much better suited
+//       for Easy API than Multi API.
+//       adbg_debugger_on_EVENT(callback) advantages over adbg_debugger_on(enum, callback):
 //       - Callback type checking (when source compiling)
 //       - Access to attributes (like `deprecated`) per function
 //       - No need to map and update enumeration values
 //       - Better documentation per function
 
-//
-// Implementation
-//
+private:
 
-/* Easy API implementation details (DRAFT)
+/* Easy API architecture (DRAFT)
 
   Windows model
   Debug API & WaitForDebugEvent functions MUST be on the same thread
   
-  User Thread <-> [Mailbox] <-> Debugger Thread + Event polling
-                                  v
-                                [Mailbox]
-                                  v
-                                Event Thread -> User Callback
+  User Thread
+    [Request Mailbox]
+      Debugger Thread + Event polling
+        On Attach/Spawn: Spawn event thread
+        On Event: [Event Mailbox] -> Event Thread -> User Callback
   
   POSIX model
   On Linux, ptrace.2 & wait.2 can be called from different threads
   Don't know for BSDs at the moment
   
-  User Thread <-> [Mailbox] <-> Debugger Thread
-                                  v
-                                <Spawns thread on spawn/attach>
-                                  v
-                                Event Thread -> User Callback
+  User Thread
+    [Request Mailbox]
+      Debugger Thread
+        On Attach/Spawn: Spawn event thread
+	On Event: Event Thread -> User Callback
 
   Requests: See Request enum
   Response: 0 for success or AdbgError
   Event: AdbgEvent
 */
 
-private:
-
-enum {
-	/// Debugger is attached.
-	EASY_ATTACHED = 1,
-	/// Process has stopped.
-	EASY_STOPPED  = 1 << 1,
-	/// Process has exited.
-	EASY_EXITED   = 1 << 2,
+enum { // Easy instance status flags
+	EASY_ATTACHED = 1 << 0,
 }
 
 //
@@ -243,17 +276,18 @@ struct adbg_easy_reply_t {
 /// 	ez = Easy instance.
 /// 	req = Request instance.
 /// 	reply_out = (Optional) If caller needs to check reply of debugging function.
-/// Return: Error code for request.
+/// Returns: Error code for request.
 int adbg_easy_request(adbg_easy_t *ez, adbg_easy_request_t *req,
 		adbg_easy_reply_t **reply_out = null) {
 	// Send request (mailbox handles blocking if full)
 	int rc = adbg_mailbox_send(&ez.request_box, message_t(0, req, 0));
 	if (rc) return rc;
 
-	// Wait for reply // TODO: timeout option
-	message_t *msg = adbg_mailbox_receivefor(&ez.reply_box, 5000);
+	// Wait for reply
+	uint timeout_ms = 5000; // TODO: timeout setting
+	message_t *msg = adbg_mailbox_receivefor(&ez.reply_box, timeout_ms);
 	if (msg == null)
-		return adbg_oops(AdbgError.assertion); // TODO: "operation timed out" error
+		return adbg_oops(AdbgError.timeout);
 
 	adbg_easy_reply_t *reply = cast(adbg_easy_reply_t*)msg.data;
 	assert(reply, "reply==NULL");
@@ -273,6 +307,8 @@ int adbg_easy_request(adbg_easy_t *ez, adbg_easy_request_t *req,
 // Easy API: Debug loop
 //
 
+enum EVENT_MSG_QUIT = 1;
+
 int adbg_easy_thread_debugger(__osthread_t *thread, void *data) {
 	assert(data);
 	adbg_easy_t *ez = cast(adbg_easy_t*)data;
@@ -284,7 +320,16 @@ Lwait:
 		message_t *msg = adbg_mailbox_receivefor(&ez.request_box, timeout_ms);
 	else
 		message_t *msg = adbg_mailbox_receive(&ez.request_box);
-	if (msg) {
+	if (msg) { // null: timeout
+		adbg_easy_request_t *req = cast(adbg_easy_request_t*)msg.data;
+		if (req.type == Request.quit) {
+			// Signal event thread to stop
+			if (ez.event_thread)
+				adbg_mailbox_send(&ez.event_box, message_t(EVENT_MSG_QUIT));
+			adbg_mailbox_send(&ez.reply_box, message_t(0, &ez.reply));
+			return 0;
+		}
+
 		int err = adbg_easy_handle_request(ez, msg);
 		if (err) {
 			ez.reply.type = Reply.error;
@@ -297,7 +342,8 @@ Lwait:
 	}
 	
 	// Windows: Poll for debugging events, and send them to event thread
-	// TODO: Check if process attached, not if exists
+	// TODO: Check if process is attached
+	//       Would make more sense, but it is an more expensive call to do in a loop
 	version (Windows)
 	if (ez.process) {
 		adbg_event_t event = void;
@@ -306,6 +352,10 @@ Lwait:
 			goto Lwait;
 		
 		adbg_mailbox_send(&ez.event_box, message_t(0, &event, adbg_event_t.sizeof));
+
+		// HACK: Continue so next WaitForDebugEvent doesn't block
+		if (event.type == AdbgEvent.exception)
+			adbg_debugger_continue(ez.process, event.exception.thread.id);
 	}
 	goto Lwait;
 }
@@ -315,54 +365,81 @@ Lwait:
 int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 	adbg_easy_request_t *req = cast(adbg_easy_request_t*)msg.data;
 	
+	version (Trace) trace("ez=%p msg=%p req=%p", ez, msg, req);
+	
+	version (Windows) uint timeout_ms = 100; // default timeout
 	switch (req.type) {
 	case Request.spawn:
+		version (Trace) trace("request:spawn path=%p", req.spawn.path);
+		
 		if (ez.process && adbg_process_is_attached(ez.process))
 			return adbg_oops(AdbgError.debuggerPresent);
 
-		adbg_process_t *proc = adbg_debugger_spawn(
+		ez.process = adbg_debugger_spawn(
 			req.spawn.path,
 			0);
-		if (proc == null) {
+		if (ez.process == null)
 			return adbg_error_code();
-		}
 
-		ez.process = proc;
-
-		// Hacks to make looping work
+		// Hacks to make multi-threaded events work
 		version (Windows)
-			adbg_debugger_option_wait_timeout(ez.process, 100);
+			adbg_debugger_option_wait_timeout(ez.process, timeout_ms);
 
+		// Make event thread
 		version (Windows)
 		ez.event_thread =
 			os_thread_new(&adbg_easy_thread_events_windows, ez);
 		version (Posix)
 		ez.event_thread =
 			os_thread_new(&adbg_easy_thread_events_posix, ez);
+		if (ez.event_thread == null)
+			return adbg_oops(AdbgError.os);
 		break;
 	case Request.attach:
+		version (Trace) trace("request:spawn pid=%p", req.attach.pid);
+		
 		if (ez.process && adbg_process_is_attached(ez.process))
 			return adbg_oops(AdbgError.debuggerPresent);
 		
-		adbg_process_t *proc = adbg_debugger_attach(req.attach.pid, 0);
-		if (proc == null) {
+		ez.process = adbg_debugger_attach(req.attach.pid, 0);
+		if (ez.process == null)
 			return adbg_error_code();
-		}
 
-		ez.process = proc;
-
+		// Hack to make multi-threaded events work
 		version (Windows)
-			adbg_debugger_option_wait_timeout(ez.process, 100);
+			adbg_debugger_option_wait_timeout(ez.process, timeout_ms);
 		
-		// Hacks to make looping work
+		// Make event thread
 		version (Windows)
-		ez.event_thread =
-			os_thread_new(&adbg_easy_thread_events_windows, ez);
+			ez.event_thread = os_thread_new(&adbg_easy_thread_events_windows, ez);
 		version (Posix)
-		ez.event_thread =
-			os_thread_new(&adbg_easy_thread_events_posix, ez);
+			ez.event_thread = os_thread_new(&adbg_easy_thread_events_posix, ez);
+		if (ez.event_thread == null)
+			return adbg_oops(AdbgError.os);
+		break;
+	case Request.quit:
+		version (Trace) trace("request:quit");
+		
+		// Signal threads to exit and wait for them to finish
+		//
+		// Terminate/detach first to unblock event threads:
+		// - POSIX: unblocks waitpid in event thread
+		// - Windows: produces processExit via WaitForDebugEvent,
+		//   which the debugger thread forwards to event_box
+		//
+		// If this doesn't work (ie, on Windows), then switch to request instead
+		if (ez.process && adbg_process_is_alive(ez.process)) {
+			int attached = adbg_process_is_attached(ez.process);
+			if (attached > 0)
+				adbg_debugger_detach(ez.process);
+			else if (attached == 0)
+				adbg_debugger_terminate(ez.process);
+			else // error
+				return attached;
+		}
 		break;
 	default:
+		version (Trace) trace("request:unknown req.type=%d", req.type);
 		return adbg_oops(AdbgError.assertion);
 	}
 	return 0;
@@ -372,32 +449,58 @@ int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 // Event loops
 //
 
-// Easy API event handler thread
+// Called from Event thread (adbg_easy_thread_events_windows or adbg_easy_thread_events_posix)
+// 
+//void adbg_easy_send_event(
+
+// Windows event thread
+//
+// Windows' Win32 Debugger API requires that both debugging requests and events
+// be done on the same thread. So, we create a thread that listens to events
+// through the event mailbox.
 version (Windows)
 int adbg_easy_thread_events_windows(__osthread_t *thread, void *data) {
 	assert(data);
 	adbg_easy_t *ez = cast(adbg_easy_t*)data;
-	
+
 Lwait:
 	message_t *msg = adbg_mailbox_receive(&ez.event_box);
-	if (msg == null)
-		goto Lwait;
-	
+	// HACK: msg.type==1 is sent by debugger thread when quitting
+	if (msg == null || msg.type == EVENT_MSG_QUIT)
+		return 0;
+
 	// TODO: Send event to user callback
 	adbg_event_t *event = cast(adbg_event_t*)msg.data;
 	adbg_process_t *process = &event.process;
-	
+
+	switch (event.type) {
+	case AdbgEvent.exception:
+		// TODO: if event callback set, call it
+		break;
 	// If the process exits, quit loop. Nothing else to wait on
-	if (event.type == AdbgEvent.processExit)
+	case AdbgEvent.processExit:
 		return 0;
+	default:
+		version (Trace) trace("not implemented: %d", event.type);
+	}
 	goto Lwait;
 }
 
+// POSIX event thread
+//
+// It has been observed that on Linux, the wait call can be called from another
+// thread. Assuming this is correct for other POSIX-complient (need to check specs),
+// we created a thread that only waits for events.
+//
+// Currently, this handles one process. If this process quits, this loop terminates.
+// We could poll for other events through the event mailbox (for better control), but
+// this should do the trick as a basic implementation.
 version (Posix)
 int adbg_easy_thread_events_posix(__osthread_t *thread, void *data) {
 	assert(data);
 	adbg_easy_t *ez = cast(adbg_easy_t*)data;
 	
+	// NOTE: When terminating, the detach/exit event makes this thread quit
 	adbg_event_t event = void;
 Lwait:
 	adbg_process_t *process = adbg_debugger_wait(ez.process, &event);
@@ -406,8 +509,16 @@ Lwait:
 	
 	// TODO: Send event to user callback
 	
+	switch (event.type) {
+	case AdbgEvent.exception:
+		// TODO: if event callback set, call it
+		adbg_debugger_continue(ez.process, event.exception.thread.id);
+		break;
 	// If the process exits, quit loop. Nothing else to wait on
-	if (event.type == AdbgEvent.processExit)
+	case AdbgEvent.processExit:
 		return 0;
+	default:
+		version (Trace) trace("not implemented: %d", event.type);
+	}
 	goto Lwait;
 }

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -8,7 +8,6 @@ module adbg.easy;
 import adbg.debugger;
 public import adbg.error;
 import adbg.os.mutex;
-import adbg.os.semaphore;
 import adbg.os.threads;
 import adbg.process.base;
 import adbg.utils.mailbox;

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -1,0 +1,98 @@
+/// 
+///
+/// Authors: dd86k <dd@dax.moe>
+/// Copyright: © dd86k <dd@dax.moe>
+/// License: BSD-3-Clause-Clear
+module adbg.easy;
+
+import adbg;
+import adbg.utils.list;
+import adbg.os.threads;
+import core.sys.openbsd.stdlib;
+import core.stdc.stdlib : calloc, free;
+
+/*
+Main Thread <-> [Mailbox] <-> Debugger Thread
+                                v
+                              [Mailbox]
+                                v
+                              Event Thread -> Client Callback
+
+
+1. Client requests action/info
+2. Adbg creates request internally
+3. Adbg Thread handles request, ownership transferred
+4. Done, handler calls client callback
+*/
+
+enum EasyReq {
+	spawn      = 100,
+	attach     = 101,
+	
+	continue_  = 200,
+	stop       = 201,
+	
+	readmem    = 500,
+	writemem   = 501,
+}
+
+enum EasyOpt {
+	dwawddawadw
+}
+
+// Buffer entry
+private
+struct adbg_easy_request_t {
+	int id;
+	
+	union {
+	
+	adbg_process_t *proc;
+	
+	} // union
+}
+
+// Instance with buffer
+struct adbg_easy_t {
+	
+	
+	list_t buffer;
+	
+	__osthread_t thread_debugger;
+	__osthread_t thread_events;
+	
+	// EVENT: On exception.
+	void function() ev_exception;
+	// EVENT: On breakpoint.
+	void function() ev_breakpoint;
+}
+
+adbg_easy_t* adbg_easy_create() {
+	
+	
+	
+	return null;
+}
+
+int adbg_easy_option(adbg_easy_t *e, int opt, void *val) {
+	return -1;
+}
+
+int adbg_easy(EasyReq req, void *data, void function(void*) callback) {
+	return -1;
+}
+
+//
+// Implementation
+//
+
+private:
+
+void adbg_easy_thread_debugger(adbg_easy_t *e) {
+	
+}
+
+version (Posix)
+void adbg_easy_thread_posix_events() {
+	
+}

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -5,40 +5,17 @@
 /// License: BSD-3-Clause-Clear
 module adbg.easy;
 
-import adbg;
-import adbg.utils.list;
+import adbg.debugger;
+import adbg.error;
+import adbg.os.mutex;
+import adbg.os.semaphore;
 import adbg.os.threads;
-import core.sys.openbsd.stdlib;
+import adbg.process.base;
+import adbg.utils.list;
+import adbg.utils.mailbox;
 import core.stdc.stdlib : calloc, free;
 
-/*
-Main Thread <-> [Mailbox] <-> Debugger Thread
-                                v
-                              [Mailbox]
-                                v
-                              Event Thread -> Client Callback
-
-
-1. Client requests action/info
-2. Adbg creates request internally
-3. Adbg Thread handles request, ownership transferred
-4. Done, handler calls client callback
-*/
-
-enum EasyReq {
-	spawn      = 100,
-	attach     = 101,
-	
-	continue_  = 200,
-	stop       = 201,
-	
-	readmem    = 500,
-	writemem   = 501,
-}
-
-enum EasyOpt {
-	dwawddawadw
-}
+extern (C):
 
 // Buffer entry
 private
@@ -47,52 +24,240 @@ struct adbg_easy_request_t {
 	
 	union {
 	
-	adbg_process_t *proc;
-	
 	} // union
 }
 
-// Instance with buffer
+/// Represents an "easy" instance.
+///
+/// This can also be seen as a Debugger instance, too.
 struct adbg_easy_t {
+	__osthread_t   debugger_thread;
+	mailbox_t      debugger_mbox;
+	mailbox_t      replies; // OK/ERROR
 	
+	__osthread_t   events_thread;
+	mailbox_t      events_mbox;
+	list_t        *events_buffer;
 	
-	list_t buffer;
+	os_mutex_t     lock;
 	
-	__osthread_t thread_debugger;
-	__osthread_t thread_events;
-	
-	// EVENT: On exception.
-	void function() ev_exception;
-	// EVENT: On breakpoint.
-	void function() ev_breakpoint;
+	adbg_process_t *process;
 }
 
 adbg_easy_t* adbg_easy_create() {
+	// 
+	adbg_easy_t *ez = cast(adbg_easy_t*)calloc(1, adbg_easy_t.sizeof);
+	if (ez == null) {
+		adbg_oops(AdbgError.crt);
+		return null;
+	}
 	
+	if (adbg_mailbox_create(&ez.debugger_mbox, 10) ||
+		adbg_mailbox_create(&ez.replies, 10) ||
+		adbg_mailbox_create(&ez.events_mbox, 10)) {
+		free(ez);
+		return null;
+	}
 	
+	if (os_mutex_init(&ez.lock)) {
+		adbg_oops(AdbgError.os);
+		free(ez);
+		return null;
+	}
 	
-	return null;
+	return ez;
 }
 
-int adbg_easy_option(adbg_easy_t *e, int opt, void *val) {
+void adbg_easy_destroy(adbg_easy_t *ez) {
+	if (ez == null) return;
+
+	// TODO: Send Quit messages
+	
+	
+}
+
+int adbg_easy_spawn(adbg_easy_t *ez, const(char) *path) {
+	if (ez == null)
+		return adbg_oops(AdbgError.invalidArgument);
+	
+	int rc = adbg_mailbox_send(&ez.debugger_mbox,
+		message_t(Request.spawn, cast(void*)path, 0));
+	if (rc) return rc;
+	
+	message_t *msg = adbg_mailbox_receivefor(&ez.replies, 5000); // TODO: timeout option
+	if (msg == null)
+		return adbg_oops(AdbgError.assertion); // TODO: timeout error
+	
+	// Set error on this thread since error stuff is TLS now
+	if (msg.type)
+		return adbg_oops(cast(AdbgError)msg.type);
+	
+	return 0;
+}
+
+int adbg_easy_attach(adbg_easy_t *ez, int pid) {
 	return -1;
 }
 
-int adbg_easy(EasyReq req, void *data, void function(void*) callback) {
-	return -1;
-}
+// NOTE: adbg_debugger_on_* advantages over adbg_debugger_on(enum)
+//       - Callback type checking (when source compiling)
+//       - Access to attributes (like `deprecated`) per function
+//       - No need to map and update enumeration values
+//       - Better documentation per function
 
 //
 // Implementation
 //
 
+/* Easy API implementation details (DRAFT)
+
+  Windows model
+  Debug API & WaitForDebugEvent functions MUST be on the same thread
+  
+  User Thread <-> [Mailbox] <-> Debugger Thread + Event polling
+                                  v
+                                [Mailbox]
+                                  v
+                                Event Thread -> User Callback
+  
+  POSIX model
+  On Linux, ptrace.2 & wait.2 can be called from different threads
+  Don't know for BSDs at the moment
+  
+  User Thread <-> [Mailbox] <-> Debugger Thread
+                                  v
+                                <Spawns thread on spawn/attach>
+                                  v
+                                Event Thread -> User Callback
+
+  Requests: See Request enum
+  Response: 0 for success or AdbgError
+  Event: AdbgEvent
+*/
+
 private:
 
-void adbg_easy_thread_debugger(adbg_easy_t *e) {
+enum Request {
+	quit       = 1,
 	
+	spawn      = 100,
+	attach     = 101,
+	
+	continue_  = 200,
+	pause      = 201,
+	
+	readmemory = 500,
+	writememory= 501,
+}
+
+struct request_spawn_t {
+	char *path;
+}
+
+enum REPLY_OK  = 0;
+
+//
+// Easy API: Debug loop
+//
+
+void adbg_easy_thread_debugger(void *data) {
+	assert(data);
+	adbg_easy_t *ez = cast(adbg_easy_t*)data;
+	
+	version (Windows) uint timeout_ms = 100;
+Lwait:
+	// Wait for a request
+	version (Windows)
+		message_t *msg = adbg_mailbox_receivefor(&ez.debugger_mbox, timeout_ms);
+	else
+		message_t *msg = adbg_mailbox_receive(&ez.debugger_mbox);
+	if (msg) {
+		cast(void)os_mutex_acquire(&ez.lock);
+		int err = adbg_easy_handle_request(ez, msg);
+		cast(void)os_mutex_release(&ez.lock);
+		if (err)
+			adbg_mailbox_send(&ez.replies, message_t(err));
+		else
+			adbg_mailbox_send(&ez.replies, message_t(REPLY_OK));
+	}
+	
+	// Check for debugging events, and send them to event thread
+	// TODO: Check if process attached, not if exists
+	version (Windows)
+	if (ez.process) {
+		adbg_event_t event = void;
+		adbg_process_t *process = adbg_debugger_wait(ez.process, &event);
+		if (process == null) {
+			goto Lwait;
+		}
+		
+		
+	}
+	goto Lwait;
+}
+
+// Just handle the request here, the caller (debugger thread) handles
+// sending the message back to the caller
+int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
+	switch (msg.type) {
+	case Request.spawn:
+		request_spawn_t *req = cast(request_spawn_t*)msg.data;
+		
+		adbg_process_t *proc = adbg_debugger_spawn(
+			req.path,
+			0);
+		if (proc == null) {
+			return adbg_error_code();
+		}
+		
+		adbg_debugger_option_wait_timeout(ez.process, 100);
+		break;
+	default:
+		return adbg_oops(AdbgError.assertion);
+	}
+	return 0;
+}
+
+//
+// Event loops
+//
+
+// Easy API event handler thread
+version (Windows)
+void adbg_easy_thread_events_windows(void *data) {
+	assert(data);
+	adbg_easy_t *ez = cast(adbg_easy_t*)data;
+	
+Lwait:
+	message_t *msg = adbg_mailbox_receive(&ez.events_mbox);
+	if (msg == null)
+		goto Lwait;
+	
+	// TODO: Send event to user callback
+	adbg_event_t *event = cast(adbg_event_t*)msg.data;
+	adbg_process_t *process = &event.process;
+	
+	// If the process exits, quit loop. Nothing else to wait on
+	if (event.type == AdbgEvent.processExit)
+		return;
+	goto Lwait;
 }
 
 version (Posix)
-void adbg_easy_thread_posix_events() {
+void adbg_easy_thread_events_posix(void *data) {
+	assert(data);
+	adbg_easy_t *ez = cast(adbg_easy_t*)data;
 	
+	adbg_event_t event = void;
+Lwait:
+	adbg_process_t *process = adbg_debugger_wait(ez.process, &event);
+	if (process == null)
+		return;
+	
+	// TODO: Send event to user callback
+	
+	// If the process exits, quit loop. Nothing else to wait on
+	if (event.type == AdbgEvent.processExit)
+		return;
+	goto Lwait;
 }

--- a/src/adbg/easy.d
+++ b/src/adbg/easy.d
@@ -126,7 +126,13 @@ int adbg_easy_spawn(adbg_easy_t *ez, const(char) *path) {
 }
 
 int adbg_easy_attach(adbg_easy_t *ez, int pid) {
-	return -1;
+	if (ez == null)
+		return adbg_oops(AdbgError.invalidArgument);
+	
+	adbg_easy_request_t req;
+	req.type = Request.attach;
+	req.attach.pid = pid;
+	return adbg_easy_request(ez, &req);
 }
 
 // NOTE: adbg_debugger_on_* advantages over adbg_debugger_on(enum)
@@ -197,11 +203,16 @@ struct adbg_easy_request_spawn_t {
 	const(char) *path;
 }
 
+struct adbg_easy_request_attach_t {
+	int pid;
+}
+
 // Buffer entry
 struct adbg_easy_request_t {
 	Request type;
 	union {
 	adbg_easy_request_spawn_t spawn;
+	adbg_easy_request_attach_t attach;
 	} // union
 }
 
@@ -228,6 +239,11 @@ struct adbg_easy_reply_t {
 
 /// Send a request to the debugger thread and wait for a reply.
 /// Optionally returns the reply pointer for callers that need response data.
+/// Params:
+/// 	ez = Easy instance.
+/// 	req = Request instance.
+/// 	reply_out = (Optional) If caller needs to check reply of debugging function.
+/// Return: Error code for request.
 int adbg_easy_request(adbg_easy_t *ez, adbg_easy_request_t *req,
 		adbg_easy_reply_t **reply_out = null) {
 	// Send request (mailbox handles blocking if full)
@@ -313,9 +329,32 @@ int adbg_easy_handle_request(adbg_easy_t *ez, message_t *msg) {
 
 		ez.process = proc;
 
+		// Hacks to make looping work
 		version (Windows)
 			adbg_debugger_option_wait_timeout(ez.process, 100);
 
+		version (Windows)
+		ez.event_thread =
+			os_thread_new(&adbg_easy_thread_events_windows, ez);
+		version (Posix)
+		ez.event_thread =
+			os_thread_new(&adbg_easy_thread_events_posix, ez);
+		break;
+	case Request.attach:
+		if (ez.process && adbg_process_is_attached(ez.process))
+			return adbg_oops(AdbgError.debuggerPresent);
+		
+		adbg_process_t *proc = adbg_debugger_attach(req.attach.pid, 0);
+		if (proc == null) {
+			return adbg_error_code();
+		}
+
+		ez.process = proc;
+
+		version (Windows)
+			adbg_debugger_option_wait_timeout(ez.process, 100);
+		
+		// Hacks to make looping work
 		version (Windows)
 		ez.event_thread =
 			os_thread_new(&adbg_easy_thread_events_windows, ez);

--- a/src/adbg/error.d
+++ b/src/adbg/error.d
@@ -196,11 +196,7 @@ package
 void adbg_error_copy(adbg_error_t *buffer) {
 	assert(buffer);
 	import core.stdc.string : memcpy;
-	memcpy(&error, buffer, adbg_error_t.sizeof);
-	/*buffer.code    = error.code;
-	buffer.func    = error.func;
-	buffer.line    = error.line;
-	buffer.modcode = error.modcode;*/
+	memcpy(buffer, &error, adbg_error_t.sizeof);
 }
 
 private

--- a/src/adbg/error.d
+++ b/src/adbg/error.d
@@ -346,6 +346,8 @@ version (Trace) {
 import core.stdc.stdio, core.stdc.stdarg;
 private import adbg.include.d.config : D_FEATURE_PRAGMA_PRINTF;
 
+// NOTE: Reminder that trace() takes printf-like formatting
+
 private
 void adbg_trace_write(const(char) *mod, const(char) *func, int line, const(char) *fmt, va_list *args) {
 	fprintf(stderr, "TRACE[%s@%u] %s: ", mod, line, func);

--- a/src/adbg/error.d
+++ b/src/adbg/error.d
@@ -77,6 +77,10 @@ enum AdbgError {
 	systemLoadError	= -402,
 	systemBindError	= -403,
 	//
+	// 500-599: Easy API
+	//
+	timeout = -500,
+	//
 	// 800-899: Memory scanner
 	//
 	scannerDataEmpty	= -800,

--- a/src/adbg/error.d
+++ b/src/adbg/error.d
@@ -102,20 +102,21 @@ enum AdbgError {
 }
 
 /// Represents an error in alicedbg.
-private
+package // easy module needs a copy of error
 struct adbg_error_t {
-	int srccode;	/// Error code from Alicedbg
+	int code;	/// Error code from Alicedbg
 	int modcode;	/// Error code for module
 	const(char)* func;	/// Source function
 	int line;	/// Line source
 }
 /// Last error in alicedbg.
-private adbg_error_t error;
+private
+adbg_error_t error; // Keep in TLS!
 
 /// Get last Alicedbg error code.
 /// Returns: Error code (AdbgError).
 int adbg_error_code() {
-	return error.srccode;
+	return error.code;
 }
 /// Get the last error from the associated module.
 /// Returns: Error code (submodule).
@@ -131,6 +132,10 @@ int adbg_error_line() {
 /// Returns: Function name.
 const(char)* adbg_error_function() {
 	return error.func;
+}
+
+adbg_error_t* adbg_error() {
+	return &error;
 }
 
 /// Get error message from the OS (or CRT) by providing the error code
@@ -163,7 +168,19 @@ const(char)* adbg_error_system_message(int code) {
 /// Reset the last set error code.
 void adbg_error_reset() {
 	// NOTE: Code is enough. Other fields are purely internal.
-	error.srccode = 0;
+	error.code = 0;
+}
+
+// Easy module needs to be able to set error for caller thread
+package
+void adbg_error_set2(adbg_error_t *e) {
+	// NOTE: Copying
+	//       Global is now in TLS, calling memcpy or doing struct copy
+	//       will make this crash
+	error.code = e.code;
+	error.func = e.func;
+	error.line = e.line;
+	error.modcode = e.modcode;
 }
 
 private
@@ -172,7 +189,7 @@ void adbg_error_set(AdbgError e, void *handle, const(char)* func, int line) {
 	error.line = line;
 	// To avoid additional errors, such as formatting,
 	// get the underlying error code now for later.
-	switch (error.srccode = e) {
+	switch (error.code = e) {
 	case AdbgError.os:
 		version (Windows)
 			error.modcode = GetLastError();
@@ -293,7 +310,7 @@ private immutable adbg_error_msg_t[] errors_msg = [
 /// Returns: Error message.
 export
 const(char)* adbg_error_message() {
-	switch (error.srccode) with (AdbgError) {
+	switch (error.code) with (AdbgError) {
 	case crt:
 		return strerror(error.modcode);
 	case os:
@@ -302,7 +319,7 @@ const(char)* adbg_error_message() {
 		return cs_strerror(error.modcode);
 	default:
 		foreach (ref e; errors_msg)
-			if (error.srccode == e.code)
+			if (error.code == e.code)
 				return e.msg.ptr;
 	}
 	return defaultMsg;

--- a/src/adbg/error.d
+++ b/src/adbg/error.d
@@ -106,7 +106,7 @@ struct adbg_error_t {
 	int line;	/// Line source
 }
 /// Last error in alicedbg.
-private __gshared adbg_error_t error;
+private adbg_error_t error;
 
 /// Get last Alicedbg error code.
 /// Returns: Error code (AdbgError).
@@ -135,9 +135,9 @@ const(char)* adbg_error_function() {
 private
 const(char)* adbg_error_system_message(int code) {
 	version (Windows) {
-		//TODO: Handle NTSTATUS codes
+		// TODO: Handle NTSTATUS codes
 		enum ERR_BUF_SZ = 256;
-		__gshared char [ERR_BUF_SZ]buffer = void;
+		static char [ERR_BUF_SZ]buffer = void;
 		size_t len = FormatMessageA(
 			FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_MAX_WIDTH_MASK,
 			null,

--- a/src/adbg/error.d
+++ b/src/adbg/error.d
@@ -134,6 +134,7 @@ const(char)* adbg_error_function() {
 	return error.func;
 }
 
+deprecated
 adbg_error_t* adbg_error() {
 	return &error;
 }
@@ -146,7 +147,7 @@ const(char)* adbg_error_system_message(int code) {
 	version (Windows) {
 		// TODO: Handle NTSTATUS codes
 		enum ERR_BUF_SZ = 256;
-		static char [ERR_BUF_SZ]buffer = void;
+		static char [ERR_BUF_SZ]buffer = void; // LTS
 		size_t len = FormatMessageA(
 			FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_MAX_WIDTH_MASK,
 			null,
@@ -167,21 +168,39 @@ const(char)* adbg_error_system_message(int code) {
 
 /// Reset the last set error code.
 void adbg_error_reset() {
-	error.code = 0;
+	import core.stdc.string : memset;
+	adbg_error_t *e = &error;
+	memset(&error, 0, adbg_error_t.sizeof);
+	/*error.code = 0;
 	error.func = null;
-	error.line = 0;
+	error.line = 0;*/
 }
 
 // Easy module needs to be able to set error for caller thread
 package
-void adbg_error_set2(adbg_error_t *e) {
+void adbg_error_paste(adbg_error_t *buffer) {
+	assert(buffer);
 	// NOTE: Copying
 	//       Global is now in TLS, calling memcpy or doing struct copy
 	//       will make this crash
-	error.code = e.code;
-	error.func = e.func;
-	error.line = e.line;
-	error.modcode = e.modcode;
+	import core.stdc.string : memcpy;
+	memcpy(&error, buffer, adbg_error_t.sizeof);
+	/*error.code    = buffer.code;
+	error.func    = buffer.func;
+	error.line    = buffer.line;
+	error.modcode = buffer.modcode;*/
+}
+deprecated alias adbg_error_set2 = adbg_error_paste;
+
+package
+void adbg_error_copy(adbg_error_t *buffer) {
+	assert(buffer);
+	import core.stdc.string : memcpy;
+	memcpy(&error, buffer, adbg_error_t.sizeof);
+	/*buffer.code    = error.code;
+	buffer.func    = error.func;
+	buffer.line    = error.line;
+	buffer.modcode = error.modcode;*/
 }
 
 private

--- a/src/adbg/error.d
+++ b/src/adbg/error.d
@@ -167,8 +167,9 @@ const(char)* adbg_error_system_message(int code) {
 
 /// Reset the last set error code.
 void adbg_error_reset() {
-	// NOTE: Code is enough. Other fields are purely internal.
 	error.code = 0;
+	error.func = null;
+	error.line = 0;
 }
 
 // Easy module needs to be able to set error for caller thread

--- a/src/adbg/include/windows/ntdll.d
+++ b/src/adbg/include/windows/ntdll.d
@@ -53,6 +53,9 @@ struct SYSTEM_BASIC_WORKING_SET_INFORMATION
 alias pNtQueryVirtualMemory =
         NTSTATUS function(HANDLE, PVOID, MEMORY_INFORMATION_CLASS, PVOID, SIZE_T, PSIZE_T);
 
+alias pNtSuspendProcess = NTSTATUS function(HANDLE);
+alias pNtResumeProcess = NTSTATUS function(HANDLE);
+
 // Source: ProcessHacker
 alias SYSTEM_INFORMATION_CLASS = int;
 enum
@@ -291,6 +294,8 @@ __gshared
 {
     pNtQueryVirtualMemory NtQueryVirtualMemory;
     pNtQuerySystemInformation NtQuerySystemInformation;
+    pNtSuspendProcess NtSuspendProcess;
+    pNtResumeProcess NtResumeProcess;
 }
 
 private __gshared bool __lib_ntdll_loaded;
@@ -307,6 +312,8 @@ bool __dynlib_ntdll_load()
     
     adbg_system_library_bind(lib, cast(void**)&NtQueryVirtualMemory, "NtQueryVirtualMemory");
     adbg_system_library_bind(lib, cast(void**)&NtQuerySystemInformation, "NtQuerySystemInformation");
+    adbg_system_library_bind(lib, cast(void**)&NtSuspendProcess, "NtSuspendProcess");
+    adbg_system_library_bind(lib, cast(void**)&NtResumeProcess, "NtResumeProcess");
     
     size_t missingcnt = adbg_system_library_missingcnt(lib);
     if (missingcnt)

--- a/src/adbg/include/windows/winbase.d
+++ b/src/adbg/include/windows/winbase.d
@@ -16,5 +16,8 @@ BOOL QueryFullProcessImageNameA(
   HANDLE hProcess,	// [in]
   DWORD  dwFlags,	// [in]
   LPSTR  lpExeName,	// [out]
-  PDWORD lpdwSize	// [in, out
+  PDWORD lpdwSize	// [in, out]
 );
+
+extern (Windows)
+BOOL DebugBreakProcess(HANDLE Process);

--- a/src/adbg/os/condvar.d
+++ b/src/adbg/os/condvar.d
@@ -1,0 +1,177 @@
+/// Condition variable primitive.
+///
+/// No user code should be using this directly, as it is used internally.
+///
+/// Windows: Uses Condition Variable API (Vista+).
+/// POSIX: Uses pthread condition variable API.
+///
+/// Authors: dd86k <dd@dax.moe>
+/// Copyright: © dd86k <dd@dax.moe>
+/// License: BSD-3-Clause-Clear
+module adbg.os.condvar;
+
+import adbg.os.lock;
+
+version (Windows) {
+	import core.sys.windows.winbase :
+		LPCRITICAL_SECTION,
+		INFINITE,
+		GetLastError;
+	import core.sys.windows.windef :
+		BOOL, FALSE, DWORD;
+	import core.sys.windows.winerror : ERROR_TIMEOUT;
+
+	// CONDITION_VARIABLE API (Vista+)
+	// Not available in druntime.
+	struct CONDITION_VARIABLE {
+		void* Ptr;
+	}
+	extern (Windows) {
+		void InitializeConditionVariable(CONDITION_VARIABLE*);
+		BOOL SleepConditionVariableCS(CONDITION_VARIABLE*, LPCRITICAL_SECTION, DWORD);
+		void WakeConditionVariable(CONDITION_VARIABLE*);
+		void WakeAllConditionVariable(CONDITION_VARIABLE*);
+	}
+
+	private alias os_condvar = CONDITION_VARIABLE;
+} else version (Posix) {
+	import core.sys.posix.pthread :
+		pthread_cond_t,
+		pthread_cond_init, pthread_cond_destroy,
+		pthread_cond_wait, pthread_cond_timedwait,
+		pthread_cond_signal, pthread_cond_broadcast,
+		pthread_mutex_t;
+
+	private alias os_condvar = pthread_cond_t;
+}
+
+struct os_condvar_t {
+	os_condvar handle;
+}
+
+/// Initialize a new condition variable.
+/// Params: cv = os_condvar_t instance.
+/// Returns: OS error code.
+int os_condvar_init(os_condvar_t *cv) {
+	assert(cv, "null condvar");
+version (Windows) {
+	InitializeConditionVariable(&cv.handle);
+} else version (Posix) {
+	pthread_cond_init(&cv.handle, null);
+} else static assert(false, "os_condvar_init");
+	return 0;
+}
+
+/// Destroy condition variable.
+/// Params: cv = os_condvar_t instance.
+void os_condvar_destroy(os_condvar_t *cv) {
+	assert(cv, "null condvar");
+version (Windows) {
+	// No-op on Windows: CONDITION_VARIABLE has no resources to release.
+} else version (Posix) {
+	pthread_cond_destroy(&cv.handle);
+} else static assert(false, "os_condvar_destroy");
+}
+
+/// Wait on a condition variable. The lock must be held by the caller.
+/// Params:
+///     cv = os_condvar_t instance.
+///     lock = os_lock_t instance (must be held).
+/// Returns: OS error code.
+int os_condvar_wait(os_condvar_t *cv, os_lock_t *lock) {
+	assert(cv, "null condvar");
+	assert(lock, "null lock");
+version (Windows) {
+	if (SleepConditionVariableCS(&cv.handle, cast(LPCRITICAL_SECTION)&lock.handle, INFINITE) == FALSE)
+		return GetLastError();
+} else version (Posix) {
+	return pthread_cond_wait(&cv.handle, &lock.handle);
+} else static assert(false, "os_condvar_wait");
+	return 0;
+}
+
+/// Wait on a condition variable for a limited amount of time.
+/// The lock must be held by the caller.
+/// Params:
+///     cv = os_condvar_t instance.
+///     lock = os_lock_t instance (must be held).
+///     ms = Timeout in milliseconds.
+///     status = Status pointer. Updated to 1 if timed out, or 0 otherwise.
+/// Returns: OS error code.
+int os_condvar_waitfor(os_condvar_t *cv, os_lock_t *lock, uint ms, int *status) {
+	assert(cv, "null condvar");
+	assert(lock, "null lock");
+version (Windows) {
+	if (SleepConditionVariableCS(&cv.handle, cast(LPCRITICAL_SECTION)&lock.handle, ms)) {
+		if (status) *status = 0;
+		return 0;
+	}
+	DWORD err = GetLastError();
+	//enum ERROR_TIMEOUT = 0x5B4;
+	if (err == ERROR_TIMEOUT) {
+		if (status) *status = 1;
+		return 0;
+	}
+	return err;
+} else version (Posix) {
+	import core.sys.posix.time : timespec, clock_gettime, CLOCK_REALTIME, time_t;
+	import core.stdc.config : c_long;
+	import core.stdc.errno : ETIMEDOUT;
+
+	time_t secs = ms / 1000;
+	c_long nsec = (ms % 1000) * 1_000_000;
+
+	timespec ts = void;
+	if (clock_gettime(CLOCK_REALTIME, &ts) < 0) {
+		import core.stdc.errno : errno;
+		return errno;
+	}
+	ts.tv_sec  += secs;
+	ts.tv_nsec += nsec;
+
+	// nsec overflow
+	enum nsec1sec = 1_000_000_000;
+	if (ts.tv_nsec >= nsec1sec) {
+		++ts.tv_sec;
+		ts.tv_nsec -= nsec1sec;
+	}
+
+	int rc = pthread_cond_timedwait(&cv.handle, &lock.handle, &ts);
+	switch (rc) {
+	case 0:
+		if (status) *status = 0;
+		return 0;
+	case ETIMEDOUT:
+		if (status) *status = 1;
+		return 0;
+	default:
+		return rc;
+	}
+} else static assert(false, "os_condvar_waitfor");
+}
+
+/// Wake one thread waiting on the condition variable.
+/// Params: cv = os_condvar_t instance.
+/// Returns: OS error code.
+int os_condvar_signal(os_condvar_t *cv) {
+	assert(cv, "null condvar");
+version (Windows) {
+	WakeConditionVariable(&cv.handle);
+} else version (Posix) {
+	return pthread_cond_signal(&cv.handle);
+} else static assert(false, "os_condvar_signal");
+	return 0;
+}
+
+/// Wake all threads waiting on the condition variable.
+/// Params: cv = os_condvar_t instance.
+/// Returns: OS error code.
+int os_condvar_broadcast(os_condvar_t *cv) {
+	assert(cv, "null condvar");
+version (Windows) {
+	WakeAllConditionVariable(&cv.handle);
+} else version (Posix) {
+	return pthread_cond_broadcast(&cv.handle);
+} else static assert(false, "os_condvar_broadcast");
+	return 0;
+}

--- a/src/adbg/os/lock.d
+++ b/src/adbg/os/lock.d
@@ -1,0 +1,83 @@
+/// Lightweight lock primitive.
+///
+/// No user code should be using this directly, as it is used internally.
+///
+/// Windows: Uses CriticalSection API (intra-process only, but faster than Mutex).
+/// POSIX: Uses pthread mutex API.
+///
+/// Authors: dd86k <dd@dax.moe>
+/// Copyright: © dd86k <dd@dax.moe>
+/// License: BSD-3-Clause-Clear
+module adbg.os.lock;
+
+version (Windows) {
+	import core.sys.windows.winbase :
+		CRITICAL_SECTION, LPCRITICAL_SECTION,
+		InitializeCriticalSection,
+		DeleteCriticalSection,
+		EnterCriticalSection,
+		LeaveCriticalSection;
+
+	private alias os_lock = CRITICAL_SECTION;
+} else version (Posix) {
+	import core.sys.posix.pthread :
+		pthread_mutex_t,
+		pthread_mutex_init, pthread_mutex_destroy,
+		pthread_mutex_lock, pthread_mutex_unlock;
+
+	private alias os_lock = pthread_mutex_t;
+}
+
+struct os_lock_t {
+	os_lock handle;
+}
+
+/// Initialize a new lock.
+/// Params: lock = os_lock_t instance.
+/// Returns: OS error code.
+int os_lock_init(os_lock_t *lock) {
+	assert(lock, "null lock");
+version (Windows) {
+	InitializeCriticalSection(&lock.handle);
+} else version (Posix) {
+	pthread_mutex_init(&lock.handle, null);
+} else static assert(false, "os_lock_init");
+	return 0;
+}
+
+/// Destroy lock.
+/// Params: lock = os_lock_t instance.
+void os_lock_destroy(os_lock_t *lock) {
+	assert(lock, "null lock");
+version (Windows) {
+	DeleteCriticalSection(&lock.handle);
+} else version (Posix) {
+	pthread_mutex_destroy(&lock.handle);
+} else static assert(false, "os_lock_destroy");
+}
+
+/// Acquire exclusive access to lock.
+/// Params: lock = os_lock_t instance.
+/// Returns: OS error code.
+int os_lock_acquire(os_lock_t *lock) {
+	assert(lock, "null lock");
+version (Windows) {
+	EnterCriticalSection(&lock.handle);
+} else version (Posix) {
+	return pthread_mutex_lock(&lock.handle);
+} else static assert(false, "os_lock_acquire");
+	return 0;
+}
+
+/// Release exclusive access from lock.
+/// Params: lock = os_lock_t instance.
+/// Returns: OS error code.
+int os_lock_release(os_lock_t *lock) {
+	assert(lock, "null lock");
+version (Windows) {
+	LeaveCriticalSection(&lock.handle);
+} else version (Posix) {
+	return pthread_mutex_unlock(&lock.handle);
+} else static assert(false, "os_lock_release");
+	return 0;
+}

--- a/src/adbg/os/mutex.d
+++ b/src/adbg/os/mutex.d
@@ -1,0 +1,148 @@
+/// Mutex primitive.
+///
+/// No user code should be using this directly, as it is used internally.
+///
+/// Windows: Uses Mutex API and not CriticalSection since the latter isn't cross-process.
+/// POSIX: Uses pthread mutex API to be available cross-process.
+///
+/// Authors: dd86k <dd@dax.moe>
+/// Copyright: © dd86k <dd@dax.moe>
+/// License: BSD-3-Clause-Clear
+module adbg.os.mutex;
+
+import adbg.utils.bit : BIT;
+
+version (Windows) {
+	import core.sys.windows.winbase :
+		GetLastError, CloseHandle,
+		CreateMutexA, WaitForSingleObject,
+		ReleaseMutex,
+		INFINITE,
+		WAIT_OBJECT_0, WAIT_ABANDONED_0, WAIT_FAILED;
+	import core.sys.windows.windef : HANDLE, FALSE, TRUE, WAIT_TIMEOUT;
+	
+	private alias HANDLE mutex_handle_t;
+} else version (Posix) {
+	import core.sys.posix.pthread :
+		pthread_mutex_t,
+		pthread_mutex_init, pthread_mutex_destroy,
+		pthread_mutex_lock, pthread_mutex_trylock, pthread_mutex_timedlock,
+		pthread_mutex_unlock;
+		// Only defined for Darwin and Solaris:
+		// pthread_mutex_getprioceiling, pthread_mutex_setprioceiling;
+	
+	private alias pthread_mutex_t mutex_handle_t;
+}
+
+// Assumptions:
+// - .handle is handled by the underlaying system for errors
+struct os_mutex_t {
+	mutex_handle_t handle;
+	int error;
+}
+
+// Having an explicit initiation function makes for a better garantee that only
+// one thread will initiate the mutex, verify the return for errors, and
+// hopefully avoid other threads access internals.
+int osmutexinit(os_mutex_t *mutex) {
+version (Windows) {
+	// Nameless Mutex that cannot be inherited
+	mutex.handle = CreateMutexA(null, FALSE, null);
+	if (mutex.handle == null) {
+		mutex.error = GetLastError();
+		return -1;
+	}
+	mutex.error = 0;
+	return 0;
+} else version (Posix) {
+	// always return zero...
+	mutex.error = pthread_mutex_init(&mutex.handle, null);
+	if (mutex.error)
+		return -1;
+	return 0;
+} // version (Posix)
+}
+
+void osmutexdestroy(os_mutex_t *mutex) {
+	if (mutex == null) assert(0, "null mutex");
+
+version (Windows) {
+	CloseHandle(mutex.handle);
+} else version (Posix) {
+	pthread_mutex_destroy(&mutex.handle);
+} // version (Posix)
+}
+
+int osmutexacquire(os_mutex_t *mutex) {
+	if (mutex == null) assert(0, "null mutex");
+
+version (Windows) {
+	// wait function is used to acquire exclusive access to mutex
+	uint rc = WaitForSingleObject(mutex.handle, INFINITE);
+	switch (rc) {
+	case WAIT_OBJECT_0, WAIT_TIMEOUT:
+		return 0;
+	default: // WAIT_ABANDONED, WAIT_FAILED
+		mutex.error = GetLastError();
+		return -1;
+	}
+} else version (Posix) {
+	mutex.error = pthread_mutex_lock(&mutex.handle);
+	if (mutex.error)
+		return -1;
+	return 0;
+} // version (Posix)
+}
+
+int osmutexacquiret(os_mutex_t *mutex, uint ms) {
+	if (mutex == null) assert(0, "null mutex");
+	
+version (Windows) {
+	// wait function is used to acquire exclusive access to mutex
+	uint rc = WaitForSingleObject(mutex.handle, ms);
+	switch (rc) {
+	case WAIT_OBJECT_0:
+		return 0;
+	case WAIT_TIMEOUT:
+		return 1;
+	default: // WAIT_ABANDONED, WAIT_FAILED
+		mutex.error = GetLastError();
+		return -1;
+	}
+} else version (Posix) {
+	import core.sys.posix.time : timespec;
+	import core.stdc.errno : ETIMEDOUT;
+	timespec s = void;
+	s.tv_sec   =  ms / 1000;
+	s.tv_nsec  = (ms % 1000) * 1_000_000; // milli -> micro -> nano
+	int rc = pthread_mutex_timedlock(&mutex.handle, &s);
+	switch (rc) {
+	case 0:
+		return 0;
+	case ETIMEDOUT:
+		return 1;
+	default:
+		mutex.error = rc;
+	}
+	return -1;
+} // version (Posix)
+}
+
+int osmutexrelease(os_mutex_t *mutex) {
+	if (mutex == null) assert(0, "null mutex");
+
+version (Windows) {
+	if (ReleaseMutex(mutex.handle) == FALSE) {
+		mutex.error = GetLastError();
+		return -1;
+	}
+	return 0;
+} else version (Posix) {
+	int rc = pthread_mutex_unlock(&mutex.handle);
+	if (rc) {
+		mutex.error = rc;
+		return -1;
+	}
+	return 0;
+} // version (Posix)
+}

--- a/src/adbg/os/mutex.d
+++ b/src/adbg/os/mutex.d
@@ -21,59 +21,61 @@ version (Windows) {
 		WAIT_OBJECT_0, WAIT_ABANDONED_0, WAIT_FAILED;
 	import core.sys.windows.windef : HANDLE, FALSE, TRUE, WAIT_TIMEOUT;
 	
-	private alias HANDLE mutex_handle_t;
+	private alias os_mutex = HANDLE;
 } else version (Posix) {
 	import core.sys.posix.pthread :
 		pthread_mutex_t,
 		pthread_mutex_init, pthread_mutex_destroy,
 		pthread_mutex_lock, pthread_mutex_trylock, pthread_mutex_timedlock,
 		pthread_mutex_unlock;
-		// Only defined for Darwin and Solaris:
-		// pthread_mutex_getprioceiling, pthread_mutex_setprioceiling;
 	
-	private alias pthread_mutex_t mutex_handle_t;
+	// Only defined for Darwin and Solaris:
+	// pthread_mutex_getprioceiling, pthread_mutex_setprioceiling;
+	
+	private alias os_mutex = pthread_mutex_t;
 }
 
 // Assumptions:
 // - .handle is handled by the underlaying system for errors
 struct os_mutex_t {
-	mutex_handle_t handle;
-	int error;
+	os_mutex handle;
 }
 
 // Having an explicit initiation function makes for a better garantee that only
 // one thread will initiate the mutex, verify the return for errors, and
 // hopefully avoid other threads access internals.
-int osmutexinit(os_mutex_t *mutex) {
+/// Initiate a new mutex.
+/// Params: mutex = os_mutex_t instance.
+/// Returns: OS error code.
+int os_mutex_init(os_mutex_t *mutex) {
 version (Windows) {
 	// Nameless Mutex that cannot be inherited
 	mutex.handle = CreateMutexA(null, FALSE, null);
-	if (mutex.handle == null) {
-		mutex.error = GetLastError();
-		return -1;
-	}
-	mutex.error = 0;
-	return 0;
+	if (mutex.handle == null)
+		return GetLastError();
 } else version (Posix) {
-	// always return zero...
-	mutex.error = pthread_mutex_init(&mutex.handle, null);
-	if (mutex.error)
-		return -1;
+	// pthread_mutex_init always return zero
+	pthread_mutex_init(&mutex.handle, null);
+} else static assert(false, "os_mutex_init");
 	return 0;
-} // version (Posix)
 }
 
-void osmutexdestroy(os_mutex_t *mutex) {
+/// Destroy mutex.
+/// Params: mutex = os_mutex_t instance.
+void os_mutex_destroy(os_mutex_t *mutex) {
 	if (mutex == null) assert(0, "null mutex");
 
 version (Windows) {
 	CloseHandle(mutex.handle);
 } else version (Posix) {
 	pthread_mutex_destroy(&mutex.handle);
-} // version (Posix)
+} else static assert(false, "os_mutex_destroy");
 }
 
-int osmutexacquire(os_mutex_t *mutex) {
+/// Acquire exclusive access to mutex.
+/// Params: mutex = os_mutex_t instance.
+/// Returns: OS error code.
+int os_mutex_acquire(os_mutex_t *mutex) {
 	if (mutex == null) assert(0, "null mutex");
 
 version (Windows) {
@@ -83,18 +85,19 @@ version (Windows) {
 	case WAIT_OBJECT_0, WAIT_TIMEOUT:
 		return 0;
 	default: // WAIT_ABANDONED, WAIT_FAILED
-		mutex.error = GetLastError();
-		return -1;
+		return GetLastError();
 	}
 } else version (Posix) {
-	mutex.error = pthread_mutex_lock(&mutex.handle);
-	if (mutex.error)
-		return -1;
-	return 0;
-} // version (Posix)
+	return pthread_mutex_lock(&mutex.handle);
+} else static assert(false, "os_mutex_acquire");
 }
 
-int osmutexacquiret(os_mutex_t *mutex, uint ms) {
+/// Acquire exclusive access to mutex, but only try for this amount of time.
+/// Params:
+///     mutex = os_mutex_t instance.
+///     ms = Timeout in millisecond.
+/// Returns: OS error code.
+int os_mutex_acquirefor(os_mutex_t *mutex, uint ms, int *status) {
 	if (mutex == null) assert(0, "null mutex");
 	
 version (Windows) {
@@ -102,47 +105,60 @@ version (Windows) {
 	uint rc = WaitForSingleObject(mutex.handle, ms);
 	switch (rc) {
 	case WAIT_OBJECT_0:
+		if (status) *status = 0;
 		return 0;
 	case WAIT_TIMEOUT:
-		return 1;
+		if (status) *status = 1;
+		return 0;
 	default: // WAIT_ABANDONED, WAIT_FAILED
-		mutex.error = GetLastError();
-		return -1;
+		return GetLastError();
 	}
 } else version (Posix) {
-	import core.sys.posix.time : timespec;
-	import core.stdc.errno : ETIMEDOUT;
-	timespec s = void;
-	s.tv_sec   =  ms / 1000;
-	s.tv_nsec  = (ms % 1000) * 1_000_000; // milli -> micro -> nano
-	int rc = pthread_mutex_timedlock(&mutex.handle, &s);
+	import core.sys.posix.time : timespec, clock_gettime, CLOCK_REALTIME, time_t;
+	import core.stdc.config : c_long;
+	import core.stdc.errno : errno, ETIMEDOUT;
+	
+	time_t secs = ms / 1000;
+	c_long nsec = (ms % 1000) * 1_000_000;
+	
+	timespec ts = void;
+	if (clock_gettime(CLOCK_REALTIME, &ts) < 0)
+		return errno;
+	ts.tv_sec  += secs;
+	ts.tv_nsec += nsec;
+	
+	// nsec overflow
+	enum nsec1sec = 1_000_000_000;
+	if (ts.tv_nsec >= nsec1sec) {
+		++ts.tv_sec;
+		ts.tv_nsec -= nsec1sec;
+	}
+	
+	int rc = pthread_mutex_timedlock(&mutex.handle, &ts);
 	switch (rc) {
 	case 0:
+		if (status) *status = 0;
 		return 0;
 	case ETIMEDOUT:
-		return 1;
+		if (status) *status = 1;
+		return 0;
 	default:
-		mutex.error = rc;
+		return rc;
 	}
-	return -1;
-} // version (Posix)
+} else static assert(false, "os_mutex_acquirefor");
 }
 
-int osmutexrelease(os_mutex_t *mutex) {
+/// Release exclusive access from mutex.
+/// Params: mutex = os_mutex_t instance.
+/// Returns: OS error code.
+int os_mutex_release(os_mutex_t *mutex) {
 	if (mutex == null) assert(0, "null mutex");
 
 version (Windows) {
-	if (ReleaseMutex(mutex.handle) == FALSE) {
-		mutex.error = GetLastError();
-		return -1;
-	}
+	if (ReleaseMutex(mutex.handle) == FALSE)
+		return GetLastError();
 	return 0;
 } else version (Posix) {
-	int rc = pthread_mutex_unlock(&mutex.handle);
-	if (rc) {
-		mutex.error = rc;
-		return -1;
-	}
-	return 0;
-} // version (Posix)
+	return pthread_mutex_unlock(&mutex.handle);
+} else static assert(false, "os_mutex_acquirefor");
 }

--- a/src/adbg/os/semaphore.d
+++ b/src/adbg/os/semaphore.d
@@ -26,9 +26,10 @@ POSIX: sem_close(3), sem_destroy(3), sem_getvalue(3), sem_init(3),
 version (Windows) {
 	import core.sys.windows.winbase;
 	import core.sys.windows.basetsd;
-	import core.sys.windows.windef : TRUE, FALSE, BOOL, WAIT_TIMEOUT;
+	import core.sys.windows.windef : TRUE, FALSE, BOOL, WAIT_TIMEOUT, DWORD;
 	
 	private alias os_semaphore = HANDLE;
+	private enum MAX_SEM_COUNT = int.max; // example doesn't elaborate
 } else version (Posix) {
 	import core.sys.posix.semaphore;
 	import core.stdc.errno : errno, ETIMEDOUT;
@@ -56,16 +57,16 @@ int os_sem_create(os_semaphore_t *sem) {
 	assert(sem, "null ptr");
 version (Windows) {
 	sem.handle = CreateSemaphoreA(
-		null, // default security
-		MAX_SEM_COUNT, // initial count
+		null,          // default security
+		0,             // initial count
 		MAX_SEM_COUNT, // maximum count
-		null); // unnamed
+		null);         // unnamed
 	if (sem.handle == null)
 		return GetLastError();
 } else version (Posix) {
 	// pshared=0 -> shared between threads of a process
-	// pshared>0 -> shared between processes (using shm
-	if (sem_init(&sem.handle, 0, SEM_VALUE_MAX) < 0)
+	// pshared>0 -> shared between processes (using shm)
+	if (sem_init(&sem.handle, 0, 0) < 0)
 		return errno;
 } else static assert(false, "osseminit");
 	return 0;
@@ -115,8 +116,8 @@ version (Windows) {
 } else version (Posix) {
 	if (sem_wait(&sem.handle) < 0)
 		return errno;
-} else static assert(false, "ossemwait");
 	return 0;
+} else static assert(false, "ossemwait");
 }
 
 // NOTE: ms could be turned into a "duration" structure at some point
@@ -145,7 +146,7 @@ version (Windows) {
 	import core.stdc.config : c_long;
 	
 	time_t secs = ms / 1000;
-	c_long nsec = (ms - (secs * 1000)) * 1_000_000;
+	c_long nsec = (ms % 1000) * 1_000_000;
 	
 	timespec ts = void;
 	if (clock_gettime(CLOCK_REALTIME, &ts) < 0)

--- a/src/adbg/os/semaphore.d
+++ b/src/adbg/os/semaphore.d
@@ -1,0 +1,173 @@
+/// Semaphone primitive.
+///
+/// No user code should be using this directly, as it is used internally.
+///
+/// Windows: Uses Win32 API.
+/// POSIX: Uses POSIX semaphores (sem_* functions).
+///
+/// Authors: dd86k <dd@dax.moe>
+/// Copyright: © dd86k <dd@dax.moe>
+/// License: BSD-3-Clause-Clear
+module adbg.os.semaphore;
+
+/* Semaphore resources
+
+Win32: CreateSemaphoreA/W, CreateSemaphoreWA/W, OpenSemaphoreW, ReleaseSemaphore,
+       WaitForSingleObject, CloseHandle
+       https://learn.microsoft.com/en-us/windows/win32/sync/semaphore-objects
+       https://learn.microsoft.com/en-us/windows/win32/sync/using-semaphore-objects
+
+POSIX: sem_close(3), sem_destroy(3), sem_getvalue(3), sem_init(3),
+       sem_open(3), sem_post(3), sem_unlink(3), sem_wait(3), pthreads(7),
+       shm_overview(7), alarm(3)
+       https://manned.org/man/sem_overview
+*/
+
+version (Windows) {
+	import core.sys.windows.winbase;
+	import core.sys.windows.basetsd;
+	import core.sys.windows.windef : TRUE, FALSE, BOOL, WAIT_TIMEOUT;
+	
+	private alias os_semaphore = HANDLE;
+} else version (Posix) {
+	import core.sys.posix.semaphore;
+	import core.stdc.errno : errno, ETIMEDOUT;
+	
+	private alias os_semaphore = sem_t;
+	
+	// SEM_VALUE_MAX is not defined anywhere in druntime.
+	version (CRuntime_Glibc)
+		private enum uint SEM_VALUE_MAX = 2147483647;
+	version (CRuntime_Bionic)
+		private enum uint SEM_VALUE_MAX = 0x3fffffff;
+	version (CRuntime_Musl)
+		private enum uint SEM_VALUE_MAX = 0x7fffffff;
+}
+
+/// Represents an OS semaphore.
+struct os_semaphore_t {
+	os_semaphore handle;
+}
+
+/// Create a new semaphore.
+/// Params: sem = os_semaphore_t pointer instance.
+/// Returns: Error code.
+int os_sem_create(os_semaphore_t *sem) {
+	assert(sem, "null ptr");
+version (Windows) {
+	sem.handle = CreateSemaphoreA(
+		null, // default security
+		MAX_SEM_COUNT, // initial count
+		MAX_SEM_COUNT, // maximum count
+		null); // unnamed
+	if (sem.handle == null)
+		return GetLastError();
+} else version (Posix) {
+	// pshared=0 -> shared between threads of a process
+	// pshared>0 -> shared between processes (using shm
+	if (sem_init(&sem.handle, 0, SEM_VALUE_MAX) < 0)
+		return errno;
+} else static assert(false, "osseminit");
+	return 0;
+}
+
+/// Closes an opened semaphore.
+/// Params: sem = os_semaphore_t pointer instance.
+/// Returns: Error code.
+void os_sem_close(os_semaphore_t *sem) {
+	assert(sem, "null ptr");
+version (Windows) {
+	CloseHandle(sem.handle);
+} else version (Posix) {
+	sem_close(&sem.handle);
+} else static assert(false, "osseminit");
+
+	import core.stdc.string : memset;
+	memset(sem, 0, os_semaphore_t.sizeof);
+}
+
+/// Notify semaphore.
+/// Params: sem = os_semaphore_t pointer instance.
+/// Returns: Error code.
+int os_sem_notify(os_semaphore_t *sem) {
+	assert(sem, "null ptr");
+version (Windows) {
+	if (ReleaseSemaphore(sem.handle, 1, null) == FALSE)
+		return GetLastError();
+} else version (Posix) {
+	if (sem_post(&sem.handle) < 0)
+		return errno;
+} else static assert(false, "ossemwaittime");
+	return 0;
+}
+
+/// Wait on a semaphore for a notification.
+/// Params: sem = os_semaphore_t pointer instance.
+/// Returns: Error code.
+int os_sem_wait(os_semaphore_t *sem) {
+	assert(sem, "null ptr");
+version (Windows) {
+	DWORD r = WaitForSingleObject(sem.handle, INFINITE);
+	switch (r) {
+	case WAIT_OBJECT_0: return 0;
+	default:            return GetLastError();
+	}
+} else version (Posix) {
+	if (sem_wait(&sem.handle) < 0)
+		return errno;
+} else static assert(false, "ossemwait");
+	return 0;
+}
+
+// NOTE: ms could be turned into a "duration" structure at some point
+/// Wait on a semaphore for limited amount of time.
+/// Params:
+///     sem = os_semaphore_t pointer instance.
+///     ms  = Timeout in millisecond.
+///     status = Status pointer. Updated to 1 if timedout, or 0 otherwise
+/// Returns: Error code.
+int os_sem_waitfor(os_semaphore_t *sem, uint ms, int *status) {
+	assert(sem, "null ptr");
+version (Windows) {
+	DWORD r = WaitForSingleObject(sem.handle, ms);
+	switch (r) {
+	case WAIT_OBJECT_0:
+		if (status) *status = 0;
+		break;
+	case WAIT_TIMEOUT:
+		if (status) *status = 1;
+		break;
+	default:
+		return GetLastError();
+	}
+} else version (Posix) {
+	import core.sys.posix.time : timespec, clock_gettime, CLOCK_REALTIME, time_t;
+	import core.stdc.config : c_long;
+	
+	time_t secs = ms / 1000;
+	c_long nsec = (ms - (secs * 1000)) * 1_000_000;
+	
+	timespec ts = void;
+	if (clock_gettime(CLOCK_REALTIME, &ts) < 0)
+		return errno;
+	ts.tv_sec  += secs;
+	ts.tv_nsec += nsec;
+	
+	// nsec overflow
+	enum nsec1sec = 1_000_000_000;
+	if (ts.tv_nsec >= nsec1sec) {
+		++ts.tv_sec;
+		ts.tv_nsec -= nsec1sec;
+	}
+	
+	// wait at absolute time
+	if (sem_timedwait(&sem.handle, &ts) < 0) {
+		int e = errno;
+		if (e == ETIMEDOUT && status)
+			*status = 1;
+		return e;
+	} else if (status)
+		*status = 0;
+} else static assert(false, "ossemwaittime");
+	return 0;
+}

--- a/src/adbg/os/threads.d
+++ b/src/adbg/os/threads.d
@@ -59,6 +59,8 @@ version (Win32Threads) {
 	private alias HANDLE thread_handle_t;
 } else version (LibcmtThreads) {
 	import core.stdc.stdint : uintptr_t;
+	import core.sys.windows.windef : HANDLE, DWORD;
+	import core.sys.windows.winbase : WaitForSingleObject, INFINITE, CloseHandle;
 	
 	// Returns -1 on error
 	extern (C)
@@ -68,7 +70,9 @@ version (Win32Threads) {
 	
 	// Returns 0 on error
 	extern (C)
-	uintptr_t _beginthreadex(void *sec, uint stk, uint function(void*) fn, void *args, uint flags, uint *thraddr);
+	//uintptr_t _beginthreadex(void *sec, uint stk, uint function(void*) fn, void *args, uint flags, uint *thraddr);
+	// NOTE: stupid extern crap being included in the type
+	uintptr_t _beginthreadex(void *sec, uint stk, void *fn, void *args, uint flags, uint *thraddr);
 	extern (C)
 	void _endthreadex(uint code);
 	
@@ -214,7 +218,7 @@ version (Win32Threads) {
 	thread.handle = _beginthreadex( // Same parameters/returns as CreateThread
 		null,                // security
 		cast(uint)size,      // stack_size
-		&osthrhandle,        // start_address
+		cast(void*)&osthrhandle,        // start_address
 		thread,              // arglist
 		THREAD_FLAGS,        // initflags
 		&thread.tid);        // thrdaddr
@@ -222,6 +226,16 @@ version (Win32Threads) {
 		free(thread);
 		return null;
 	}
+	/*
+	thread.handle = _beginthread(
+		&osthrhandle,
+		cast(uint)size,
+		thread);
+	if (thread.handle == -1) {
+		free(thread);
+		return null;
+	}
+	*/
 	
 	return thread;
 } else version (MFCThreads) {
@@ -264,8 +278,8 @@ uint osthrhandle(void *data) {
 // _beginthread: __cdecl void function(void*)
 // _beginthreadex: __stdcall unsigned function(void*)
 version (LibcmtThreads)
-extern (Windows) // __stdcall
 private
+extern (Windows) // __stdcall
 uint osthrhandle(void *data) {
 	assert(data, "data is null");
 	__osthread_t *thread = cast(__osthread_t*)data;
@@ -286,8 +300,8 @@ uint osthrhandle(void *data) {
 
 // Thread handler for MFC threads
 version (MFCThreads)
-extern (Windows)
 private
+extern (Windows)
 void osthrhandle(void *data) {
 	assert(data, "data is null");
 	__osthread_t *thread = cast(__osthread_t*)data;

--- a/src/adbg/os/threads.d
+++ b/src/adbg/os/threads.d
@@ -1,0 +1,415 @@
+/// Implements threading facilities.
+///
+/// No user code should be using this directly, as it is used internally.
+///
+/// The threading model used might depend on the compilation target.
+///
+/// Authors: dd86k <dd@dax.moe>
+/// Copyright: © dd86k <dd@dax.moe>
+/// License: BSD-3-Clause-Clear
+module adbg.os.threads;
+
+import adbg.os.mutex;
+import core.stdc.stdlib : malloc, calloc, free;
+import core.stdc.string : memset;
+import core.sys.posix.sys.mman;
+
+// NOTE: Thread models
+//
+//       NT RTL
+//         Mentioned through headers, means native WindowsNT threads, but this
+//         isn't generally available to Windows user applications.
+//
+//       Win32
+//         Base model with CreateThread and (not) TerminateThread.
+//
+//       Libcmt (recommended Win32 wrapper for msvc)
+//         Uses _beginthread/_beginthreadex and _endthread/_endthreadex.
+//         https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/beginthread-beginthreadex?view=msvc-170
+//         https://learn.microsoft.com/en-us/cpp/parallel/multithreading-with-c-and-win32?view=msvc-170
+//
+//       MFC
+//         Uses AfxBeginThread that returns CWinThread.
+//         https://learn.microsoft.com/en-us/cpp/parallel/multithreading-terminating-threads?view=msvc-170
+//
+//       PThread (POSIX Threads)
+//         On Windows, in rare cases, when a wrapper like MinGW or Mingw-w64 is involved,
+//         it might use a PThreads model. Usually doesn't (at least using DMD and LDC).
+
+// TODO: Error codes
+// Optional: Thread priority
+// Optional: Thread names (SetThreadDescription: Windows 10+; pthread_set_name_np: Linux/macOS)
+
+version (Windows) {
+	//version = Win32Threads;
+	version = LibcmtThreads;
+	//version = MFCThreads;
+	//version = PosixThreads;
+	
+	// winbase.h, version 10.0.19041.0
+	enum STACK_SIZE_PARAM_IS_A_RESERVATION = 0x00010000;
+} else version (Posix) {
+	version = PosixThreads;
+}
+
+version (Win32Threads) {
+	import core.sys.windows.winbase;
+	import core.sys.windows.windef;
+	
+	private alias HANDLE thread_handle_t;
+} else version (LibcmtThreads) {
+	import core.stdc.stdint : uintptr_t;
+	
+	// Returns -1 on error
+	extern (C)
+	uintptr_t _beginthread(void function(void*) fn, uint stk, void *args);
+	extern (C)
+	void _endthread();
+	
+	// Returns 0 on error
+	extern (C)
+	uintptr_t _beginthreadex(void *sec, uint stk, uint function(void*) fn, void *args, uint flags, uint *thraddr);
+	extern (C)
+	void _endthreadex(uint code);
+	
+	// In MS examples, this is casted to HANDLE for WaitForSingleObject.
+	private alias uintptr_t thread_handle_t;
+} else version (MFCThreads) {
+	struct CWinThread;
+	/* C++
+	CWinThread* AfxBeginThread(
+		AFX_THREADPROC pfnThreadProc,
+		LPVOID pParam,
+		int nPriority = THREAD_PRIORITY_NORMAL,
+		UINT nStackSize = 0,
+		DWORD dwCreateFlags = 0,
+		LPSECURITY_ATTRIBUTES lpSecurityAttrs = NULL);
+
+	CWinThread* AfxBeginThread(
+		CRuntimeClass* pThreadClass,
+		int nPriority = THREAD_PRIORITY_NORMAL,
+		UINT nStackSize = 0,
+		DWORD dwCreateFlags = 0,
+		LPSECURITY_ATTRIBUTES lpSecurityAttrs = NULL);
+	*/
+	// Callback: UINT __cdecl MyControllingFunction( LPVOID pParam );
+	static assert(0, "TODO: MFCThreads");
+} else version (PosixThreads) {
+	import core.sys.posix.pthread;
+	
+	// pthread_t is typically c_ulong
+	private alias pthread_t thread_handle_t;
+}
+
+extern (C):
+
+enum {
+	/// Status: Thread is running
+	__OSTHREAD_RUNNING = 1,
+	/// Status: Thread has been requested to be canceled
+	__OSTHREAD_CANCELED = 4,
+	
+	// No error.
+	//__OSTERR_OK = 0,
+	// 
+	//__OSTERR_NOALLOC = -2,
+}
+
+struct __osthread_t {
+	thread_handle_t handle;
+	int function(__osthread_t*, void*) ufunc;
+	void *udata;
+	int status;
+	int code;
+	// NOTE: Mutexes
+	//       Not a performance option v. atomics, but offers more
+	//       consistent and deterministic behavior
+	os_mutex_t mutex;
+	version (Win32Threads) uint tid;
+	version (LibcmtThreads) uint tid;
+}
+
+const(char)* osthrmodel() {
+	version (Win32Threads)
+		return "win32";
+	version (LibcmtThreads)
+		return "libcmt";
+	version (MFCThreads)
+		return "mfc";
+	version (PosixThreads)
+		return "pthread";
+}
+
+/// Sleep caller thread by this amount of time.
+/// Params: ms = Milliseconds.
+void ossleep(uint ms) {
+version (Windows) {
+	import core.sys.windows.winbase : Sleep;
+	Sleep(ms);
+} else version (Posix) {
+	// usleep is removed in POSIX.1-2008
+	import core.sys.posix.time : nanosleep, timespec, time_t;
+	import core.stdc.config : c_long;
+	import core.stdc.errno : errno, EINTR;
+	timespec r = void, s = void;
+	s.tv_sec   = cast(time_t)(ms / 1000);
+	s.tv_nsec  = cast(c_long)((ms % 1000) * 1_000_000); // milli -> micro -> nano
+Lsleep:
+	// On success, quit
+	if (nanosleep(&s, &r) >= 0)
+		return;
+	// Not interrupted means something else happened
+	if (errno != EINTR)
+		return;
+	// Retry with remaining time
+	s.tv_sec = r.tv_sec;
+	s.tv_nsec = r.tv_nsec;
+	goto Lsleep;
+} // version (Posix)
+}
+
+/// Create and execute a new remote thread.
+///
+/// New threads need to use `osthrcancel
+/// Params:
+/// 	func = Function (must be externed as C).
+/// 	data = Pointer to data to be passed to function.
+/// 	size = Stack size in Bytes. 0 meaning to use the default size.
+/// Returns: Thread instance, or null on error.
+__osthread_t* osthrnew(int function(__osthread_t*, void*) func, void *data = null, size_t size = 0) {
+	assert(func, "func is null");
+	
+	__osthread_t* thread = cast(__osthread_t*)calloc(1, __osthread_t.sizeof);
+	if (thread == null) {
+		return null;
+	}
+	/*__osthread_t* thread = cast(__osthread_t*)mmap(null, 4096,
+		PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANON, 0, 0);
+	if (thread == MAP_FAILED)
+		return null;*/
+	if (osmutexinit(&thread.mutex) < 0) {
+		free(thread);
+		return null;
+	}
+	
+	thread.ufunc = func;
+	thread.udata = data;
+version (Win32Threads) {
+	enum THREAD_FLAGS = STACK_SIZE_PARAM_IS_A_RESERVATION;
+	thread.handle = CreateThread(
+		null,                // lpThreadAttributes
+		cast(SIZE_T)size,    // dwStackSize
+		&osthrhandle,        // lpStartAddress
+		thread,              // lpParameter
+		THREAD_FLAGS,        // dwCreationFlags
+		&thread.tid);        // lpThreadId
+	if (thread.handle == null) {
+		free(thread);
+		return null;
+	}
+	
+	return thread;
+} else version (LibcmtThreads) {
+	enum THREAD_FLAGS = STACK_SIZE_PARAM_IS_A_RESERVATION;
+	thread.handle = _beginthreadex( // Same parameters/returns as CreateThread
+		null,                // security
+		cast(uint)size,      // stack_size
+		&osthrhandle,        // start_address
+		thread,              // arglist
+		THREAD_FLAGS,        // initflags
+		&thread.tid);        // thrdaddr
+	if (thread.handle == 0) {
+		free(thread);
+		return null;
+	}
+	
+	return thread;
+} else version (MFCThreads) {
+	static assert(0, "TODO: MFCThreads");
+} else version (PosixThreads) {
+	int r = pthread_create(&thread.handle, null, &osthrhandle, thread);
+	if (r) {
+		free(thread);
+		return null;
+	}
+	
+	return thread;
+} else {
+	static assert(0, "Threading API unavailable");
+} // version (PosixThreads)
+}
+
+// Thread handler for Win32 threads
+version (Win32Threads)
+private
+uint osthrhandle(void *data) {
+	assert(data, "data is null");
+	__osthread_t *thread = cast(__osthread_t*)data;
+	
+	osmutexacquire(&thread.mutex);
+	thread.status |= __OSTHREAD_RUNNING;
+	osmutexrelease(&thread.mutex);
+	
+	int rc = thread.func(thread, thread.udata);
+	
+	osmutexacquire(&thread.mutex);
+	thread.status &= ~__OSTHREAD_RUNNING;
+	thread.code = rc;
+	osmutexrelease(&thread.mutex);
+	
+	return rc; // implicit ExitThread(code)
+}
+
+// Thread handler for Win32-CRT threads
+// _beginthread: __cdecl void function(void*)
+// _beginthreadex: __stdcall unsigned function(void*)
+version (LibcmtThreads)
+extern (Windows) // __stdcall
+private
+uint osthrhandle(void *data) {
+	assert(data, "data is null");
+	__osthread_t *thread = cast(__osthread_t*)data;
+	
+	osmutexacquire(&thread.mutex);
+	thread.status |= __OSTHREAD_RUNNING;
+	osmutexrelease(&thread.mutex);
+	
+	int rc = thread.ufunc(thread, thread.udata);
+	
+	osmutexacquire(&thread.mutex);
+	thread.status &= ~__OSTHREAD_RUNNING;
+	thread.code = rc;
+	osmutexrelease(&thread.mutex);
+	
+	return rc; // implicit _endthreadex(code);
+}
+
+// Thread handler for MFC threads
+version (MFCThreads)
+extern (Windows)
+private
+void osthrhandle(void *data) {
+	assert(data, "data is null");
+	__osthread_t *thread = cast(__osthread_t*)data;
+	
+	osmutexacquire(&thread.mutex);
+	thread.status |= __OSTHREAD_RUNNING;
+	osmutexrelease(&thread.mutex);
+	
+	int rc = thread.ufunc(thread, thread.udata);
+	
+	osmutexacquire(&thread.mutex);
+	thread.status &= ~__OSTHREAD_RUNNING;
+	thread.code = rc;
+	osmutexrelease(&thread.mutex);
+	
+	AfxEndThread(rc, TRUE);
+}
+
+version (PosixThreads)
+private
+void* osthrhandle(void *data) {
+	assert(data, "data is null");
+	__osthread_t *thread = cast(__osthread_t*)data;
+	
+	osmutexacquire(&thread.mutex);
+	thread.status |= __OSTHREAD_RUNNING;
+	osmutexrelease(&thread.mutex);
+	
+	int rc = thread.ufunc(thread, thread.udata);
+	
+	osmutexacquire(&thread.mutex);
+	thread.status &= ~__OSTHREAD_RUNNING;
+	thread.code = rc;
+	osmutexrelease(&thread.mutex);
+	
+	pthread_exit(&thread.code);
+	return null;
+}
+
+/// Detach a thread (only available on POSIX threads).
+/// Params: thread = Thread.
+/// Returns: Zero on success, otherwise error number.
+version (PosixThreads)
+int osthrdetach(__osthread_t *thread) {
+	assert(thread, "thread is NULL");
+	
+	if (pthread_detach(thread.handle))
+		return -1;
+	
+	return 0;
+}
+
+/// Wait for a thread to finish.
+///
+/// If a thread was detached, it is no longer joinable.
+/// Params: thread = Thread.
+/// Returns: Exit code, or -1 on error.
+int osthrjoin(__osthread_t *thread) {
+	assert(thread, "thread is NULL");
+	
+	// Because we manually save exit code, no need to use OS functions
+	// to get the remote thread's exit code.
+version (PosixThreads) {
+	void *ret = void;
+	if (pthread_join(thread.handle, &ret))
+		return -1;
+	
+	int code = thread.code;
+	
+	osthrdestroy(thread);
+	
+	return code;
+} else { // Libcmt/Win32, MFC will be implemented later
+	// If MS examples casts the thread handle, so can I.
+	HANDLE handle = cast(HANDLE)thread.handle;
+	assert(handle, "handle is NULL"); // TODO: Handle as error
+	DWORD r = WaitForSingleObject(handle, INFINITE);
+	CloseHandle(handle); // close anyway
+	
+	int code = thread.code;
+	osthrdestroy(thread);
+	
+	// r: WAIT_ABANDONED, WAIT_OBJECT_0+n, WAIT_TIMEOUT, WAIT_FAILED
+	// Right now, if anything happened, consider as error.
+	return r ? -1 : code;
+}
+	return 0;
+}
+
+/// Request cancelation of a thread.
+/// Params: thread = Thread.
+void osthrcancel(__osthread_t *thread) {
+	assert(thread, "thread is null");
+	
+	// TODO: Consider atomic
+	osmutexacquire(&thread.mutex);
+	thread.status |= __OSTHREAD_CANCELED;
+	osmutexrelease(&thread.mutex);
+}
+
+/// Get internal status flags.
+///
+/// Allows manually querying for RUNNING and CANCELED statuses.
+/// Params: thread = Thread.
+/// Returns: Status flags.
+int osthrstatus(__osthread_t *thread) {
+	assert(thread, "thread is null");
+	
+	// TODO: Consider atomic
+	osmutexacquire(&thread.mutex);
+	int status = thread.status;
+	osmutexrelease(&thread.mutex);
+	
+	return status;
+}
+
+/// Destroy a thread. Called internally when remote thread finishes.
+/// Params: thread = Thread.
+private
+void osthrdestroy(__osthread_t *thread) {
+	assert(thread, "thread is null");
+	
+	osmutexdestroy(&thread.mutex);
+	free(thread);
+}

--- a/src/adbg/os/threads.d
+++ b/src/adbg/os/threads.d
@@ -114,16 +114,23 @@ enum {
 	__OSTHREAD_CANCELED = 4,
 	
 	// No error.
-	//__OSTERR_OK = 0,
-	// 
-	//__OSTERR_NOALLOC = -2,
+	__OSTERR_OK = 0,
+	// OS error.
+	__OSTERR_OS = -1,
+	// Allocation failed.
+	__OSTERR_NOALLOC = -2,
 }
 
 struct __osthread_t {
+	// OS thread handle
 	thread_handle_t handle;
+	// User function
 	int function(__osthread_t*, void*) ufunc;
+	// User data
 	void *udata;
+	// Thread status
 	int status;
+	// Exit code
 	int code;
 	// NOTE: Mutexes
 	//       Not a performance option v. atomics, but offers more
@@ -359,21 +366,21 @@ int osthrdetach(__osthread_t *thread) {
 /// If a thread was detached, it is no longer joinable.
 /// Params: thread = Thread.
 /// Returns: Exit code, or -1 on error.
-int osthrjoin(__osthread_t *thread) {
+int osthrjoin(__osthread_t *thread, int *exitcode = null) {
 	assert(thread, "thread is NULL");
 	
 	// Because we manually save exit code, no need to use OS functions
 	// to get the remote thread's exit code.
 version (PosixThreads) {
-	void *ret = void;
-	if (pthread_join(thread.handle, &ret))
+	if (pthread_join(thread.handle, null))
 		return -1;
 	
-	int code = thread.code;
+	if (exitcode)
+		*exitcode = thread.code;
 	
 	osthrdestroy(thread);
 	
-	return code;
+	return 0;
 } else { // Libcmt/Win32, MFC will be implemented later
 	// If MS examples casts the thread handle, so can I.
 	HANDLE handle = cast(HANDLE)thread.handle;
@@ -381,14 +388,15 @@ version (PosixThreads) {
 	DWORD r = WaitForSingleObject(handle, INFINITE);
 	CloseHandle(handle); // close anyway
 	
-	int code = thread.code;
+	if (exitcode)
+		*exitcode = thread.code;
+	
 	osthrdestroy(thread);
 	
-	// r: WAIT_ABANDONED, WAIT_OBJECT_0+n, WAIT_TIMEOUT, WAIT_FAILED
-	// Right now, if anything happened, consider as error.
-	return r ? -1 : code;
+	// Error: WAIT_ABANDONED, WAIT_TIMEOUT, WAIT_FAILED
+	// WAIT_OBJECT_0 (0) is OK.
+	return r ? -1 : 0;
 }
-	return 0;
 }
 
 /// Request cancelation of a thread.

--- a/src/adbg/os/threads.d
+++ b/src/adbg/os/threads.d
@@ -56,7 +56,7 @@ version (Win32Threads) {
 	import core.sys.windows.winbase;
 	import core.sys.windows.windef;
 	
-	private alias HANDLE thread_handle_t;
+	private alias os_thread = HANDLE;
 } else version (LibcmtThreads) {
 	import core.stdc.stdint : uintptr_t;
 	import core.sys.windows.windef : HANDLE, DWORD;
@@ -77,7 +77,7 @@ version (Win32Threads) {
 	void _endthreadex(uint code);
 	
 	// In MS examples, this is casted to HANDLE for WaitForSingleObject.
-	private alias uintptr_t thread_handle_t;
+	private alias os_thread = uintptr_t;
 } else version (MFCThreads) {
 	struct CWinThread;
 	/* C++
@@ -102,7 +102,7 @@ version (Win32Threads) {
 	import core.sys.posix.pthread;
 	
 	// pthread_t is typically c_ulong
-	private alias pthread_t thread_handle_t;
+	private alias os_thread = pthread_t;
 }
 
 extern (C):
@@ -123,7 +123,7 @@ enum {
 
 struct __osthread_t {
 	// OS thread handle
-	thread_handle_t handle;
+	os_thread handle;
 	// User function
 	int function(__osthread_t*, void*) ufunc;
 	// User data
@@ -140,7 +140,9 @@ struct __osthread_t {
 	version (LibcmtThreads) uint tid;
 }
 
-const(char)* osthrmodel() {
+/// Returns the short name of the thread model in use for target.
+/// Returns: Short name.
+const(char)* os_thread_model() {
 	version (Win32Threads)
 		return "win32";
 	version (LibcmtThreads)
@@ -153,7 +155,7 @@ const(char)* osthrmodel() {
 
 /// Sleep caller thread by this amount of time.
 /// Params: ms = Milliseconds.
-void ossleep(uint ms) {
+void os_thread_sleep(uint ms) {
 version (Windows) {
 	import core.sys.windows.winbase : Sleep;
 	Sleep(ms);
@@ -180,25 +182,18 @@ Lsleep:
 }
 
 /// Create and execute a new remote thread.
-///
-/// New threads need to use `osthrcancel
 /// Params:
 /// 	func = Function (must be externed as C).
 /// 	data = Pointer to data to be passed to function.
 /// 	size = Stack size in Bytes. 0 meaning to use the default size.
 /// Returns: Thread instance, or null on error.
-__osthread_t* osthrnew(int function(__osthread_t*, void*) func, void *data = null, size_t size = 0) {
+__osthread_t* os_thread_new(int function(__osthread_t*, void*) func, void *data = null, size_t size = 0) {
 	assert(func, "func is null");
 	
 	__osthread_t* thread = cast(__osthread_t*)calloc(1, __osthread_t.sizeof);
-	if (thread == null) {
+	if (thread == null)
 		return null;
-	}
-	/*__osthread_t* thread = cast(__osthread_t*)mmap(null, 4096,
-		PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANON, 0, 0);
-	if (thread == MAP_FAILED)
-		return null;*/
-	if (osmutexinit(&thread.mutex) < 0) {
+	if (os_mutex_init(&thread.mutex) < 0) {
 		free(thread);
 		return null;
 	}
@@ -267,16 +262,16 @@ uint osthrhandle(void *data) {
 	assert(data, "data is null");
 	__osthread_t *thread = cast(__osthread_t*)data;
 	
-	osmutexacquire(&thread.mutex);
+	os_mutex_acquire(&thread.mutex);
 	thread.status |= __OSTHREAD_RUNNING;
-	osmutexrelease(&thread.mutex);
+	os_mutex_release(&thread.mutex);
 	
 	int rc = thread.func(thread, thread.udata);
 	
-	osmutexacquire(&thread.mutex);
+	os_mutex_acquire(&thread.mutex);
 	thread.status &= ~__OSTHREAD_RUNNING;
 	thread.code = rc;
-	osmutexrelease(&thread.mutex);
+	os_mutex_release(&thread.mutex);
 	
 	return rc; // implicit ExitThread(code)
 }
@@ -291,16 +286,16 @@ uint osthrhandle(void *data) {
 	assert(data, "data is null");
 	__osthread_t *thread = cast(__osthread_t*)data;
 	
-	osmutexacquire(&thread.mutex);
+	os_mutex_acquire(&thread.mutex);
 	thread.status |= __OSTHREAD_RUNNING;
-	osmutexrelease(&thread.mutex);
+	os_mutex_release(&thread.mutex);
 	
 	int rc = thread.ufunc(thread, thread.udata);
 	
-	osmutexacquire(&thread.mutex);
+	os_mutex_acquire(&thread.mutex);
 	thread.status &= ~__OSTHREAD_RUNNING;
 	thread.code = rc;
-	osmutexrelease(&thread.mutex);
+	os_mutex_release(&thread.mutex);
 	
 	return rc; // implicit _endthreadex(code);
 }
@@ -313,16 +308,16 @@ void osthrhandle(void *data) {
 	assert(data, "data is null");
 	__osthread_t *thread = cast(__osthread_t*)data;
 	
-	osmutexacquire(&thread.mutex);
+	os_mutex_acquire(&thread.mutex);
 	thread.status |= __OSTHREAD_RUNNING;
-	osmutexrelease(&thread.mutex);
+	os_mutex_release(&thread.mutex);
 	
 	int rc = thread.ufunc(thread, thread.udata);
 	
-	osmutexacquire(&thread.mutex);
+	os_mutex_acquire(&thread.mutex);
 	thread.status &= ~__OSTHREAD_RUNNING;
 	thread.code = rc;
-	osmutexrelease(&thread.mutex);
+	os_mutex_release(&thread.mutex);
 	
 	AfxEndThread(rc, TRUE);
 }
@@ -333,16 +328,16 @@ void* osthrhandle(void *data) {
 	assert(data, "data is null");
 	__osthread_t *thread = cast(__osthread_t*)data;
 	
-	osmutexacquire(&thread.mutex);
+	os_mutex_acquire(&thread.mutex);
 	thread.status |= __OSTHREAD_RUNNING;
-	osmutexrelease(&thread.mutex);
+	os_mutex_release(&thread.mutex);
 	
 	int rc = thread.ufunc(thread, thread.udata);
 	
-	osmutexacquire(&thread.mutex);
+	os_mutex_acquire(&thread.mutex);
 	thread.status &= ~__OSTHREAD_RUNNING;
 	thread.code = rc;
-	osmutexrelease(&thread.mutex);
+	os_mutex_release(&thread.mutex);
 	
 	pthread_exit(&thread.code);
 	return null;
@@ -352,7 +347,7 @@ void* osthrhandle(void *data) {
 /// Params: thread = Thread.
 /// Returns: Zero on success, otherwise error number.
 version (PosixThreads)
-int osthrdetach(__osthread_t *thread) {
+int os_thread_detach(__osthread_t *thread) {
 	assert(thread, "thread is NULL");
 	
 	if (pthread_detach(thread.handle))
@@ -366,7 +361,7 @@ int osthrdetach(__osthread_t *thread) {
 /// If a thread was detached, it is no longer joinable.
 /// Params: thread = Thread.
 /// Returns: Exit code, or -1 on error.
-int osthrjoin(__osthread_t *thread, int *exitcode = null) {
+int os_thread_join(__osthread_t *thread, int *exitcode = null) {
 	assert(thread, "thread is NULL");
 	
 	// Because we manually save exit code, no need to use OS functions
@@ -401,13 +396,13 @@ version (PosixThreads) {
 
 /// Request cancelation of a thread.
 /// Params: thread = Thread.
-void osthrcancel(__osthread_t *thread) {
+void os_thread_cancel(__osthread_t *thread) {
 	assert(thread, "thread is null");
 	
 	// TODO: Consider atomic
-	osmutexacquire(&thread.mutex);
+	os_mutex_acquire(&thread.mutex);
 	thread.status |= __OSTHREAD_CANCELED;
-	osmutexrelease(&thread.mutex);
+	os_mutex_release(&thread.mutex);
 }
 
 /// Get internal status flags.
@@ -419,9 +414,9 @@ int osthrstatus(__osthread_t *thread) {
 	assert(thread, "thread is null");
 	
 	// TODO: Consider atomic
-	osmutexacquire(&thread.mutex);
+	os_mutex_acquire(&thread.mutex);
 	int status = thread.status;
-	osmutexrelease(&thread.mutex);
+	os_mutex_release(&thread.mutex);
 	
 	return status;
 }
@@ -432,6 +427,6 @@ private
 void osthrdestroy(__osthread_t *thread) {
 	assert(thread, "thread is null");
 	
-	osmutexdestroy(&thread.mutex);
+	os_mutex_destroy(&thread.mutex);
 	free(thread);
 }

--- a/src/adbg/process/base.d
+++ b/src/adbg/process/base.d
@@ -48,6 +48,10 @@ enum {
 	ADBG_PROCESS_STOPPED  = 1 << 1,
 	/// Process has exited.
 	ADBG_PROCESS_EXITED   = 1 << 2,
+	/// Debug-break requested (for event correlation).
+	ADBG_PROCESS_PAUSED   = 1 << 3,
+	/// OS-level suspended. Requires special handling.
+	ADBG_PROCESS_SUSPENDED = 1 << 4,
 	
 	/// Linux: /proc/PID/mem couldn't be opened, so do not depend on it
 	__PROC_STATUS_NO_PROC_MEM = 1 << 16,
@@ -107,6 +111,15 @@ int adbg_process_is_alive(adbg_process_t *proc) {
 		return adbg_oops(AdbgError.invalidArgument);
 	
 	return (proc.status & ADBG_PROCESS_EXITED) == 0;
+}
+/// Check if process is paused or suspended.
+/// Params: proc = Process.
+/// Returns: Positive value if paused/suspended, zero if not, or negative value on error.
+int adbg_process_is_paused(adbg_process_t *proc) {
+	if (proc == null)
+		return adbg_oops(AdbgError.invalidArgument);
+
+	return proc.status & (ADBG_PROCESS_PAUSED | ADBG_PROCESS_SUSPENDED);
 }
 
 void adbg_process_free(adbg_process_t *proc) {

--- a/src/adbg/process/base.d
+++ b/src/adbg/process/base.d
@@ -53,8 +53,7 @@ enum {
 	__PROC_STATUS_NO_PROC_MEM = 1 << 16,
 }
 
-// TODO: Any params used to spawn/attach to a process SHOULD be held in a new structure
-//       Either "adbg_debugger_t" (if generic oriented) or "adbg_tracee_t"
+// TODO: (Idea) Consider a "adbg_tracee_t" structure to diversify internals
 //       adbg_process_t should only have PID.
 /// Represents an instance of a process.
 struct adbg_process_t {
@@ -63,7 +62,7 @@ version (Windows) {
 	HANDLE orig_handle;	/// Original Process Handle
 	char *orig_args;	/// Saved arguments when process was launched
 	DWORD pid;	/// Process ID
-	uint option_timeout;
+	uint option_timeout;	/// For adbg_debugger_wait specifically
 }
 version (Posix) {
 	pid_t orig_pid;	/// Original spawned PID

--- a/src/adbg/process/base.d
+++ b/src/adbg/process/base.d
@@ -17,6 +17,7 @@ module adbg.process.base;
 //       Linux: Send SIGSTOP/SIGCONT signals via kill(2)
 // TODO: Functions to spawn process without debugger.
 // TODO: Functions to attach process without debugger.
+// TODO: Rename module to adbg.process.process.
 
 import adbg.include.c.stdlib; // malloc, calloc, free, exit;
 import adbg.include.c.stdarg;
@@ -46,6 +47,7 @@ enum AdbgProcessState : ubyte {
 	created,	/// Process was created by debugger and waiting to run.
 	running,	/// Process is running.
 	stopped,	/// Process is paused due to an exception or by the debugger.
+	exited,	/// Process exited.
 }
 
 /// Process creation source.
@@ -57,10 +59,22 @@ enum AdbgCreation : ubyte {
 }
 
 package enum {
+	/// Debugger is attached.
+	ADBG_PROCESS_ATTACHED = 1,
+	/// Process has stopped.
+	ADBG_PROCESS_STOPPED  = 1 << 1,
+	/// Process has exited.
+	ADBG_PROCESS_EXITED   = 1 << 2,
+}
+
+package enum {
 	/// Linux: /proc/PID/mem couldn't be opened, so do not depend on it
 	__PROC_STATUS_NO_PROC_MEM = 1 << 16,
 }
 
+// TODO: Any params used to spawn/attach to a process SHOULD be held in a new structure
+//       Either "adbg_debugger_t" (if generic oriented) or "adbg_tracee_t"
+//       adbg_process_t should only have PID.
 /// Represents an instance of a process.
 struct adbg_process_t {
 version (Windows) {
@@ -77,25 +91,20 @@ version (Posix) {
 			// On Linux, the starting thread ID is the same as the process ID
 }
 version (linux) {
-	int mhandle;	/// Internal memory file handle to /proc/PID/mem
+	int procmemfd;	/// Internal memory file handle to /proc/PID/mem
+	deprecated alias mhandle = procmemfd; // Older alias
 }
 	/// Internal status
 	int status;
 	
+	// TODO: Remove state & creation to rely on statuses
+	//       - debugger attached
+	//       - process is stopped
+	//       - process exited
 	/// Last known process status.
-	AdbgProcessState state;
+	deprecated AdbgProcessState state;
 	/// Process' creation source.
-	AdbgCreation creation;
-	// List of breakpoints.
-	//list_t *breakpoint_list;
-	
-	// HACK: Debugger event handlers
-	void function(adbg_process_t*, void *udata, adbg_exception_t *ex) event_exception;
-//	void function(adbg_process_t*, void *udata) event_process_created;
-	// TODO: Consider moving `int code` to `int *code`
-	void function(adbg_process_t*, void *udata, int code) event_process_exited;
-	// TODO: Consider moving `long tid` to `adbg_process_thread_t *thread`
-	void function(adbg_process_t*, void *udata, long tid) event_process_continued;
+	deprecated AdbgCreation creation;
 	
 	// HACK: Event user data (when attached in wait)
 	void *udata;
@@ -113,7 +122,7 @@ void adbg_process_free(adbg_process_t *proc) {
 		if (proc.orig_argv) free(proc.orig_argv);
 	}
 	version (linux) {
-		if (proc.mhandle) close(proc.mhandle);
+		if (proc.procmemfd) close(proc.procmemfd);
 	}
 	free(proc);
 }
@@ -136,6 +145,7 @@ const(char)* adbg_process_status_string(adbg_process_t *tracee) pure {
 	case created:	return "created";
 	case running:	return "running";
 	case stopped:	return "stopped";
+	case exited:	return "exited";
 	case unknown:	return default_;
 	}
 }
@@ -251,10 +261,10 @@ version (LinuxPersonality) {
 	int fd = open(path.ptr, O_RDONLY);
 	if (fd < 0)
 		return adbg_machine_current();
-	// TODO: Extend to 16 chars just in case
-	if (read(fd, path.ptr, 8)) // re-use buffer that's no longer needed
+	enum RDLEN = 16;
+	if (read(fd, path.ptr, RDLEN)) // re-use buffer that's no longer needed
 		return adbg_machine_current();
-	path[8] = 0;
+	path[RDLEN] = 0;
 	char *end = void;
 	uint personality = cast(uint)strtol(path.ptr, &end, 16);
 	enum LINUX32 = PER_LINUX_32BIT | PER_LINUX32 | PER_LINUX32_3GB;
@@ -262,6 +272,10 @@ version (LinuxPersonality) {
 }
 	return adbg_machine_current();
 }
+
+//
+// Process list
+//
 
 /// Create a list of processes running on the system.
 /// Returns: Internal list; Or null on error.

--- a/src/adbg/process/base.d
+++ b/src/adbg/process/base.d
@@ -41,33 +41,14 @@ version (Windows) {
 
 extern (C):
 
-/// Process status
-enum AdbgProcessState : ubyte {
-	unknown,	/// Process status is not known.
-	created,	/// Process was created by debugger and waiting to run.
-	running,	/// Process is running.
-	stopped,	/// Process is paused due to an exception or by the debugger.
-	exited,	/// Process exited.
-}
-
-/// Process creation source.
-enum AdbgCreation : ubyte {
-	unattached,
-	unloaded = unattached, // Older alias
-	attached,
-	spawned,
-}
-
-package enum {
+enum {
 	/// Debugger is attached.
 	ADBG_PROCESS_ATTACHED = 1,
 	/// Process has stopped.
 	ADBG_PROCESS_STOPPED  = 1 << 1,
 	/// Process has exited.
 	ADBG_PROCESS_EXITED   = 1 << 2,
-}
-
-package enum {
+	
 	/// Linux: /proc/PID/mem couldn't be opened, so do not depend on it
 	__PROC_STATUS_NO_PROC_MEM = 1 << 16,
 }
@@ -92,22 +73,31 @@ version (Posix) {
 }
 version (linux) {
 	int procmemfd;	/// Internal memory file handle to /proc/PID/mem
-	deprecated alias mhandle = procmemfd; // Older alias
 }
 	/// Internal status
 	int status;
 	
-	// TODO: Remove state & creation to rely on statuses
-	//       - debugger attached
-	//       - process is stopped
-	//       - process exited
-	/// Last known process status.
-	deprecated AdbgProcessState state;
-	/// Process' creation source.
-	deprecated AdbgCreation creation;
-	
 	// HACK: Event user data (when attached in wait)
 	void *udata;
+}
+
+int adbg_process_is_attached(adbg_process_t *proc) {
+	if (proc == null)
+		return adbg_oops(AdbgError.invalidArgument);
+	
+	return proc.status & ADBG_PROCESS_ATTACHED;
+}
+int adbg_process_is_stopped(adbg_process_t *proc) {
+	if (proc == null)
+		return adbg_oops(AdbgError.invalidArgument);
+	
+	return proc.status & ADBG_PROCESS_STOPPED;
+}
+int adbg_process_is_alive(adbg_process_t *proc) {
+	if (proc == null)
+		return adbg_oops(AdbgError.invalidArgument);
+	
+	return (proc.status & ADBG_PROCESS_EXITED) == 0;
 }
 
 void adbg_process_free(adbg_process_t *proc) {
@@ -125,29 +115,6 @@ void adbg_process_free(adbg_process_t *proc) {
 		if (proc.procmemfd) close(proc.procmemfd);
 	}
 	free(proc);
-}
-
-/// Get the debuggee's current status.
-/// Params: tracee = Debugged process.
-/// Returns: Debuggee status.
-AdbgProcessState adbg_process_status(adbg_process_t *tracee) pure {
-	if (tracee == null) return AdbgProcessState.unknown;
-	return tracee.state;
-}
-/// Get the debuggee current status as a string.
-/// Params: tracee = Debugged process.
-/// Returns: Debuggee status string.
-const(char)* adbg_process_status_string(adbg_process_t *tracee) pure {
-	static immutable const(char) *default_ = "unknown";
-	if (tracee == null)
-		return default_;
-	final switch (tracee.state) with (AdbgProcessState) {
-	case created:	return "created";
-	case running:	return "running";
-	case stopped:	return "stopped";
-	case exited:	return "exited";
-	case unknown:	return default_;
-	}
 }
 
 /// Get the process ID.

--- a/src/adbg/process/base.d
+++ b/src/adbg/process/base.d
@@ -80,18 +80,28 @@ version (linux) {
 	void *udata;
 }
 
+/// Check if process was attached, as opposed to spawned.
+/// Params: proc = Process.
+/// Returns: Positive value if it was attached, zero if not, or negative value on error.
 int adbg_process_is_attached(adbg_process_t *proc) {
 	if (proc == null)
 		return adbg_oops(AdbgError.invalidArgument);
 	
 	return proc.status & ADBG_PROCESS_ATTACHED;
 }
+/// Check if process is in a stopped state, useful to know if it is safe to
+/// call continue.
+/// Params: proc = Process.
+/// Returns: Positive value if stopped, zero if not, or negative value on error.
 int adbg_process_is_stopped(adbg_process_t *proc) {
 	if (proc == null)
 		return adbg_oops(AdbgError.invalidArgument);
 	
 	return proc.status & ADBG_PROCESS_STOPPED;
 }
+/// Check if process is still alive (ie, not exited).
+/// Params: proc = Process.
+/// Returns: Positive value if stopped, zero if not, or negative value on error.
 int adbg_process_is_alive(adbg_process_t *proc) {
 	if (proc == null)
 		return adbg_oops(AdbgError.invalidArgument);

--- a/src/adbg/process/memory.d
+++ b/src/adbg/process/memory.d
@@ -79,7 +79,7 @@ int __adbg_memory_open_linux(adbg_process_t *proc) {
 		//       because there are no particular soft warnings about this
 		return -1;
 	}
-	proc.mhandle = fd;
+	proc.procmemfd = fd;
 	return 0;
 }
 
@@ -128,12 +128,12 @@ version (Windows) {
 	// then /proc/PID/mem is unavaialble, skip it
 	if ((proc.status & __PROC_STATUS_NO_PROC_MEM) == 0) {
 		// Since the handle is unopened, open an handle to /proc/PID/mem
-		if (proc.mhandle == 0 && __adbg_memory_open_linux(proc))
+		if (proc.procmemfd == 0 && __adbg_memory_open_linux(proc))
 			goto Lptrace;
 		
 		// If it succeeds, return immediately.
 		// Otherwise, try via ptrace(3)
-		if (read(proc.mhandle, data, size) >= 0)
+		if (read(proc.procmemfd, data, size) >= 0)
 			return 0;
 	}
 	
@@ -222,12 +222,12 @@ version (Windows) {
 	// then /proc/PID/mem is unavaialble, skip it
 	if ((proc.status & __PROC_STATUS_NO_PROC_MEM) == 0) {
 		// Since the handle is unopened, open an handle to /proc/PID/mem
-		if (proc.mhandle == 0 && __adbg_memory_open_linux(proc))
+		if (proc.procmemfd == 0 && __adbg_memory_open_linux(proc))
 			goto Lptrace;
 		
 		// If it succeeds, return immediately.
 		// Otherwise, try via ptrace(3)
-		if (write(proc.mhandle, data, size) >= 0)
+		if (write(proc.procmemfd, data, size) >= 0)
 			return 0;
 	}
 	

--- a/src/adbg/process/memory.d
+++ b/src/adbg/process/memory.d
@@ -5,7 +5,7 @@
 /// License: BSD-3-Clause-Clear
 module adbg.process.memory;
 
-import adbg.process.base : AdbgProcessState, adbg_process_t, __PROC_STATUS_NO_PROC_MEM;
+import adbg.process.base : adbg_process_t, __PROC_STATUS_NO_PROC_MEM;
 import adbg.include.c.stdlib;
 import adbg.include.c.stdarg;
 import core.stdc.string : memcpy;

--- a/src/adbg/self.d
+++ b/src/adbg/self.d
@@ -48,11 +48,10 @@ extern (C):
 
 adbg_process_t* adbg_self_process() {
 	__gshared adbg_process_t proc;
-	proc.creation = AdbgCreation.unloaded;
-	proc.state = AdbgProcessState.running;
+	proc.status = 0;
 version (Windows) {
 	proc.pid = GetCurrentProcessId();
-	// GetCurrentThreadId();
+	// TODO: GetCurrentThreadId();
 } else version (linux) {
 	proc.pid = getpid();
 	// TODO: gettid(2)

--- a/src/adbg/utils/mailbox.d
+++ b/src/adbg/utils/mailbox.d
@@ -10,7 +10,26 @@ import adbg.os.mutex;
 import adbg.os.semaphore;
 import adbg.os.threads;
 import core.stdc.stdlib : calloc, malloc, free;
-import core.stdc.string : memset, memcpy;
+import core.stdc.string : memset, memcpy, memmove;
+
+// NOTE: std.concurrency.MessageBox & Multithreading
+//
+//       Currently, this implementation assumes one producer and one consumer, but
+//       wasn't designed to handle multiple producers and consumers.
+//
+//       Mailboxes in Phobos uses the MessageBox class (phobos/std/concurrency.d),
+//       which uses a Lock (mutex) and two Conditions.
+//
+//       Conditions (druntime/src/core/sync/condition.d) are typically implemented
+//       using one PThread condition and one lock (mutex).
+//
+//       On Windows, Conditions are implemented using Algorithm 8c:
+//       http://groups.google.com/group/comp.programming.threads/browse_frm/thread/1692bdec8040ba40/e7a5f9d40e86503a
+//
+//       However, since Vista, Conditional Variables exist:
+//       https://learn.microsoft.com/en-us/windows/win32/Sync/condition-variables
+//       https://learn.microsoft.com/en-us/windows/win32/Sync/using-condition-variables
+//       
 
 struct message_t {
 	int type;
@@ -68,7 +87,6 @@ void adbg_mailbox_destroy(mailbox_t *box) {
 //       In std.concurrency, options are to wait, throw (error), or skip
 
 int adbg_mailbox_send(mailbox_t *box, message_t msg) {
-	// TODO: adbg_oops is not thread safe
 	if (box == null)
 		return adbg_oops(AdbgError.invalidArgument);
 	
@@ -77,11 +95,39 @@ int adbg_mailbox_send(mailbox_t *box, message_t msg) {
 		cast(void)os_mutex_release(&box.mutex);
 		// TODO: Wait until capacity available again
 		//       Or make it a stategy
-		// TODO: adbg_oops is not thread safe
 		return adbg_oops(AdbgError.assertion);
 	}
 	memcpy(box.messages + box.count, &msg, message_t.sizeof);
 	box.count++;
+	cast(void)os_mutex_release(&box.mutex);
+	
+	os_sem_notify(&box.sem);
+	return 0;
+}
+
+int adbg_mailbox_send_priority(mailbox_t *box, message_t msg) {
+	if (box == null)
+		return adbg_oops(AdbgError.invalidArgument);
+	
+	cast(void)os_mutex_acquire(&box.mutex);
+	
+	if (box.count >= box.capacity) {
+		cast(void)os_mutex_release(&box.mutex);
+		// TODO: Wait until capacity available again
+		//       Or make it a stategy
+		return adbg_oops(AdbgError.assertion);
+	}
+	
+	// Move items by one message
+	memmove(
+		box.messages + 1, // to
+		box.messages,     // from
+		message_t.sizeof * box.count); // size
+	
+	// Copy to [0]
+	memcpy(box.messages, &msg, message_t.sizeof);
+	box.count++;
+	
 	cast(void)os_mutex_release(&box.mutex);
 	
 	os_sem_notify(&box.sem);

--- a/src/adbg/utils/mailbox.d
+++ b/src/adbg/utils/mailbox.d
@@ -1,35 +1,19 @@
 /// Provides a Mailbox API.
 ///
+/// Uses a lock and two condition variables (not_empty / not_full) to implement
+/// a bounded producer-consumer queue. Senders block when the mailbox is full;
+/// receivers block when it is empty.
+///
 /// Authors: dd86k <dd@dax.moe>
 /// Copyright: © dd86k <dd@dax.moe>
 /// License: BSD-3-Clause-Clear
 module adbg.utils.mailbox;
 
 import adbg.error;
-import adbg.os.mutex;
-import adbg.os.semaphore;
-import adbg.os.threads;
+import adbg.os.lock;
+import adbg.os.condvar;
 import core.stdc.stdlib : calloc, malloc, free;
 import core.stdc.string : memset, memcpy, memmove;
-
-// NOTE: std.concurrency.MessageBox & Multithreading
-//
-//       Currently, this implementation assumes one producer and one consumer, but
-//       wasn't designed to handle multiple producers and consumers.
-//
-//       Mailboxes in Phobos uses the MessageBox class (phobos/std/concurrency.d),
-//       which uses a Lock (mutex) and two Conditions.
-//
-//       Conditions (druntime/src/core/sync/condition.d) are typically implemented
-//       using one PThread condition and one lock (mutex).
-//
-//       On Windows, Conditions are implemented using Algorithm 8c:
-//       http://groups.google.com/group/comp.programming.threads/browse_frm/thread/1692bdec8040ba40/e7a5f9d40e86503a
-//
-//       However, since Vista, Conditional Variables exist:
-//       https://learn.microsoft.com/en-us/windows/win32/Sync/condition-variables
-//       https://learn.microsoft.com/en-us/windows/win32/Sync/using-condition-variables
-//       
 
 struct message_t {
 	int type;
@@ -43,110 +27,110 @@ struct mailbox_t {
 	message_t *messages;
 	size_t capacity;
 	size_t count; // current count (index)
-	
-	os_mutex_t mutex;
-	os_semaphore_t sem;
+
+	os_lock_t    lock;
+	os_condvar_t not_empty; // signaled when count > 0
+	os_condvar_t not_full;  // signaled when count < capacity
 }
 
 // capacity=mailbox size
 int adbg_mailbox_create(mailbox_t *box, size_t capacity) {
 	if (box == null || capacity == 0)
 		return adbg_oops(AdbgError.invalidArgument);
-	
+
 	box.messages = cast(message_t*)malloc(message_t.sizeof * capacity);
 	if (box.messages == null)
 		return adbg_oops(AdbgError.crt);
-	
+
 	box.capacity = capacity;
 	box.count    = 0;
-	
-	if (os_mutex_init(&box.mutex)) {
+
+	if (os_lock_init(&box.lock)) {
 		free(box.messages);
 		return adbg_oops(AdbgError.os);
 	}
-	if (os_sem_create(&box.sem)) {
+	if (os_condvar_init(&box.not_empty)) {
 		free(box.messages);
 		return adbg_oops(AdbgError.os);
 	}
-	
+	if (os_condvar_init(&box.not_full)) {
+		free(box.messages);
+		return adbg_oops(AdbgError.os);
+	}
+
 	return 0;
 }
+
 void adbg_mailbox_destroy(mailbox_t *box) {
 	if (box == null) return;
-	
-	// TODO: wait/close stuff
-	
+
 	free(box.messages);
-	os_mutex_destroy(&box.mutex);
-	os_sem_close(&box.sem);
-	
+	os_condvar_destroy(&box.not_full);
+	os_condvar_destroy(&box.not_empty);
+	os_lock_destroy(&box.lock);
+
 	memset(box, 0, mailbox_t.sizeof);
 }
-
-// TODO: On crowding (full) behavior function option
-//       In std.concurrency, options are to wait, throw (error), or skip
 
 int adbg_mailbox_send(mailbox_t *box, message_t msg) {
 	if (box == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	
-	cast(void)os_mutex_acquire(&box.mutex);
-	if (box.count >= box.capacity) {
-		cast(void)os_mutex_release(&box.mutex);
-		// TODO: Wait until capacity available again
-		//       Or make it a stategy
-		return adbg_oops(AdbgError.assertion);
-	}
+
+	cast(void)os_lock_acquire(&box.lock);
+
+	// Block until space is available
+	while (box.count >= box.capacity)
+		os_condvar_wait(&box.not_full, &box.lock);
+
 	memcpy(box.messages + box.count, &msg, message_t.sizeof);
 	box.count++;
-	cast(void)os_mutex_release(&box.mutex);
-	
-	os_sem_notify(&box.sem);
+
+	os_condvar_signal(&box.not_empty);
+	cast(void)os_lock_release(&box.lock);
+
 	return 0;
 }
 
 int adbg_mailbox_send_priority(mailbox_t *box, message_t msg) {
 	if (box == null)
 		return adbg_oops(AdbgError.invalidArgument);
-	
-	cast(void)os_mutex_acquire(&box.mutex);
-	
-	if (box.count >= box.capacity) {
-		cast(void)os_mutex_release(&box.mutex);
-		// TODO: Wait until capacity available again
-		//       Or make it a stategy
-		return adbg_oops(AdbgError.assertion);
-	}
-	
+
+	cast(void)os_lock_acquire(&box.lock);
+
+	// Block until space is available
+	while (box.count >= box.capacity)
+		os_condvar_wait(&box.not_full, &box.lock);
+
 	// Move items by one message
 	memmove(
 		box.messages + 1, // to
 		box.messages,     // from
 		message_t.sizeof * box.count); // size
-	
+
 	// Copy to [0]
 	memcpy(box.messages, &msg, message_t.sizeof);
 	box.count++;
-	
-	cast(void)os_mutex_release(&box.mutex);
-	
-	os_sem_notify(&box.sem);
+
+	os_condvar_signal(&box.not_empty);
+	cast(void)os_lock_release(&box.lock);
+
 	return 0;
 }
 
 message_t* adbg_mailbox_receive(mailbox_t *box) {
 	if (box == null)
 		return null;
-	
-	os_sem_wait(&box.sem);
-	
-	os_mutex_acquire(&box.mutex);
-	if (box.count == 0) {
-		cast(void)os_mutex_release(&box.mutex);
-		return null;
-	}
+
+	cast(void)os_lock_acquire(&box.lock);
+
+	// Block until a message is available
+	while (box.count == 0)
+		os_condvar_wait(&box.not_empty, &box.lock);
+
 	message_t *msg = &box.messages[--box.count];
-	os_mutex_release(&box.mutex);
+
+	os_condvar_signal(&box.not_full);
+	cast(void)os_lock_release(&box.lock);
 
 	return msg;
 }
@@ -155,17 +139,21 @@ message_t* adbg_mailbox_receivefor(mailbox_t *box, uint ms) {
 	if (box == null)
 		return null;
 
-	int status = void;
-	if (os_sem_waitfor(&box.sem, ms, &status) || status) // error or timeout
-		return null;
+	cast(void)os_lock_acquire(&box.lock);
 
-	os_mutex_acquire(&box.mutex);
-	if (box.count == 0) {
-		cast(void)os_mutex_release(&box.mutex);
-		return null;
+	while (box.count == 0) {
+		int status = void;
+		if (os_condvar_waitfor(&box.not_empty, &box.lock, ms, &status) || status) {
+			// error or timeout
+			cast(void)os_lock_release(&box.lock);
+			return null;
+		}
 	}
+
 	message_t *msg = &box.messages[--box.count];
-	os_mutex_release(&box.mutex);
+
+	os_condvar_signal(&box.not_full);
+	cast(void)os_lock_release(&box.lock);
 
 	return msg;
 }

--- a/src/adbg/utils/mailbox.d
+++ b/src/adbg/utils/mailbox.d
@@ -145,27 +145,27 @@ message_t* adbg_mailbox_receive(mailbox_t *box) {
 		cast(void)os_mutex_release(&box.mutex);
 		return null;
 	}
-	message_t *msg = &box.messages[box.count--];
+	message_t *msg = &box.messages[--box.count];
 	os_mutex_release(&box.mutex);
-	
+
 	return msg;
 }
 
 message_t* adbg_mailbox_receivefor(mailbox_t *box, uint ms) {
 	if (box == null)
 		return null;
-	
+
 	int status = void;
 	if (os_sem_waitfor(&box.sem, ms, &status) || status) // error or timeout
 		return null;
-	
+
 	os_mutex_acquire(&box.mutex);
 	if (box.count == 0) {
 		cast(void)os_mutex_release(&box.mutex);
 		return null;
 	}
-	message_t *msg = &box.messages[box.count--];
+	message_t *msg = &box.messages[--box.count];
 	os_mutex_release(&box.mutex);
-	
+
 	return msg;
 }

--- a/src/adbg/utils/mailbox.d
+++ b/src/adbg/utils/mailbox.d
@@ -1,0 +1,115 @@
+/// Provides a Mailbox API.
+///
+/// Authors: dd86k <dd@dax.moe>
+/// Copyright: © dd86k <dd@dax.moe>
+/// License: BSD-3-Clause-Clear
+module adbg.utils.mailbox;
+
+import adbg.error;
+import adbg.os.mutex;
+import adbg.os.semaphore;
+import adbg.os.threads;
+import core.stdc.stdlib : calloc, malloc, free;
+import core.stdc.string : memset, memcpy;
+
+struct message_t {
+	int type;
+	void *data;
+	size_t size;
+}
+
+struct mailbox_t {
+	// queue
+	message_t *messages;
+	size_t capacity;
+	size_t count; // current count (index)
+	
+	os_mutex_t mutex;
+	os_semaphore_t sem;
+}
+
+// capacity=mailbox size
+int adbg_mailbox_create(mailbox_t *box, size_t capacity) {
+	if (box == null || capacity == 0)
+		return adbg_oops(AdbgError.invalidArgument);
+	
+	box.messages = cast(message_t*)malloc(message_t.sizeof * capacity);
+	if (box.messages == null)
+		return adbg_oops(AdbgError.crt);
+	
+	box.capacity = capacity;
+	box.count    = 0;
+	
+	os_mutex_init(&box.mutex);
+	os_sem_create(&box.sem);
+	
+	return 0;
+}
+void adbg_mailbox_destroy(mailbox_t *box) {
+	if (box == null) return;
+	
+	// TODO: wait/close stuff
+	
+	free(box.messages);
+	os_mutex_destroy(&box.mutex);
+	os_sem_close(&box.sem);
+	
+	memset(box, 0, mailbox_t.sizeof);
+}
+
+int adbg_mailbox_send(mailbox_t *box, message_t msg) {
+	// TODO: adbg_oops is not thread safe
+	if (box == null)
+		return adbg_oops(AdbgError.invalidArgument);
+	
+	cast(void)os_mutex_acquire(&box.mutex);
+	if (box.count >= box.capacity) {
+		cast(void)os_mutex_release(&box.mutex);
+		// TODO: Wait until capacity available again
+		//       Or make it a stategy
+		// TODO: adbg_oops is not thread safe
+		return adbg_oops(AdbgError.assertion);
+	}
+	memcpy(box.messages + box.count, &msg, message_t.sizeof);
+	box.count++;
+	cast(void)os_mutex_release(&box.mutex);
+	
+	os_sem_notify(&box.sem);
+	return 0;
+}
+
+message_t* adbg_mailbox_receive(mailbox_t *box) {
+	if (box == null)
+		return null;
+	
+	os_sem_wait(&box.sem);
+	
+	os_mutex_acquire(&box.mutex);
+	if (box.count == 0) {
+		cast(void)os_mutex_release(&box.mutex);
+		return null;
+	}
+	message_t *msg = &box.messages[box.count--];
+	os_mutex_release(&box.mutex);
+	
+	return msg;
+}
+
+message_t* adbg_mailbox_receivefor(mailbox_t *box, uint ms) {
+	if (box == null)
+		return null;
+	
+	int status = void;
+	if (os_sem_waitfor(&box.sem, ms, &status) || status)
+		return null;
+	
+	os_mutex_acquire(&box.mutex);
+	if (box.count == 0) {
+		cast(void)os_mutex_release(&box.mutex);
+		return null;
+	}
+	message_t *msg = &box.messages[box.count--];
+	os_mutex_release(&box.mutex);
+	
+	return msg;
+}

--- a/src/adbg/utils/mailbox.d
+++ b/src/adbg/utils/mailbox.d
@@ -15,6 +15,7 @@ import core.stdc.string : memset, memcpy;
 struct message_t {
 	int type;
 	void *data;
+	/// Size of data excluding this structure
 	size_t size;
 }
 
@@ -40,8 +41,14 @@ int adbg_mailbox_create(mailbox_t *box, size_t capacity) {
 	box.capacity = capacity;
 	box.count    = 0;
 	
-	os_mutex_init(&box.mutex);
-	os_sem_create(&box.sem);
+	if (os_mutex_init(&box.mutex)) {
+		free(box.messages);
+		return adbg_oops(AdbgError.os);
+	}
+	if (os_sem_create(&box.sem)) {
+		free(box.messages);
+		return adbg_oops(AdbgError.os);
+	}
 	
 	return 0;
 }
@@ -56,6 +63,9 @@ void adbg_mailbox_destroy(mailbox_t *box) {
 	
 	memset(box, 0, mailbox_t.sizeof);
 }
+
+// TODO: On crowding (full) behavior function option
+//       In std.concurrency, options are to wait, throw (error), or skip
 
 int adbg_mailbox_send(mailbox_t *box, message_t msg) {
 	// TODO: adbg_oops is not thread safe
@@ -100,7 +110,7 @@ message_t* adbg_mailbox_receivefor(mailbox_t *box, uint ms) {
 		return null;
 	
 	int status = void;
-	if (os_sem_waitfor(&box.sem, ms, &status) || status)
+	if (os_sem_waitfor(&box.sem, ms, &status) || status) // error or timeout
 		return null;
 	
 	os_mutex_acquire(&box.mutex);

--- a/tests/easy-target.d
+++ b/tests/easy-target.d
@@ -1,0 +1,8 @@
+module tests.easy.target;
+
+extern (C):
+
+void main() {
+	void function() bad;
+	bad();
+}

--- a/tests/easy-target.d
+++ b/tests/easy-target.d
@@ -1,8 +1,11 @@
 module tests.easy.target;
 
-extern (C):
+import core.thread : Thread;
+import std.datetime : dur;
 
-void main() {
+void main(string[] args) {
+	if (args.length > 1) Thread.sleep(dur!"msecs"(500));
+	
 	void function() bad;
 	bad();
 }

--- a/tests/easy.d
+++ b/tests/easy.d
@@ -20,13 +20,14 @@ void enforce(bool cond, string func,
 		file, line);
 }
 
+enum SRC = "tests/easy-target.d";
+version (Windows) enum EXEC="easy-target.exe";
+else              enum EXEC="./easy-target";
+import std.file : exists;
+import std.process : spawnProcess, Pid;
+
+/// Example of spawning
 unittest {
-	enum SRC = "tests/easy-target.d";
-	version (Windows) enum EXEC="easy-target.exe";
-	else              enum EXEC="./easy-target";
-	
-	import std.file : exists;
-	
 	// 0. Check if target exists
 	//    Unbothered to detect dmd/gdc/ldc and perform a compile
 	//    Do that yourself
@@ -51,4 +52,29 @@ unittest {
 	adbg_easy_destroy(ez);
 }
 
-// TODO: Variant to attach
+/// Example of attaching
+unittest {
+	// 0. Check if target exists
+	//    Unbothered to detect dmd/gdc/ldc and perform a compile
+	//    Do that yourself
+	if (exists(EXEC) == false) {
+		writeln("easy: target does not exist");
+		writeln("easy: compile '", SRC, "' as '", EXEC, "'");
+		writeln("easy: then re-run this test");
+		assert(false, "Compile target and run this test again");
+	}
+	
+	// 1. Create easy instance
+	adbg_easy_t *ez = adbg_easy_create();
+	enforce(ez != null, "adbg_easy_create");
+	
+	// 2. Spawn executable and attach to it
+	Pid proc = spawnProcess([ EXEC, "1" ]);
+	enforce(adbg_easy_attach(ez, proc.processID) == 0, "adbg_easy_attach");
+	
+	// 3. Is it really alive?
+	enforce(adbg_easy_process_is_alive(ez) > 0, "adbg_easy_process_is_alive");
+	
+	// Destroy! We'll know if it hangs
+	adbg_easy_destroy(ez);
+}

--- a/tests/easy.d
+++ b/tests/easy.d
@@ -43,4 +43,12 @@ unittest {
 	
 	// 2. Spawn executable
 	enforce(adbg_easy_spawn(ez, EXEC) == 0, "adbg_easy_spawn");
+	
+	// 3. Is it really alive?
+	enforce(adbg_easy_process_is_alive(ez) > 0, "adbg_easy_process_is_alive");
+	
+	// Destroy! We'll know if it hangs
+	adbg_easy_destroy(ez);
 }
+
+// TODO: Variant to attach

--- a/tests/easy.d
+++ b/tests/easy.d
@@ -1,7 +1,7 @@
 module tests.easy;
 
 import adbg.easy;
-
+import std.stdio : writeln;
 
 void enforce(bool cond, string func,
 	size_t line = __LINE__, string file = __FILE__) {
@@ -31,7 +31,6 @@ unittest {
 	//    Unbothered to detect dmd/gdc/ldc and perform a compile
 	//    Do that yourself
 	if (exists(EXEC) == false) {
-		import std.stdio : writeln;
 		writeln("easy: target does not exist");
 		writeln("easy: compile '", SRC, "' as '", EXEC, "'");
 		writeln("easy: then re-run this test");

--- a/tests/easy.d
+++ b/tests/easy.d
@@ -34,7 +34,7 @@ unittest {
 		writeln("easy: target does not exist");
 		writeln("easy: compile '", SRC, "' as '", EXEC, "'");
 		writeln("easy: then re-run this test");
-		return;
+		assert(false, "Compile target and run this test again");
 	}
 	
 	// 1. Create easy instance

--- a/tests/easy.d
+++ b/tests/easy.d
@@ -1,0 +1,44 @@
+module tests.easy;
+
+import adbg.easy;
+
+
+void enforce(bool cond, string msg,
+	size_t line = __LINE__, string file = __FILE__) {
+	if (cond) return;
+	
+	import std.string : fromStringz;
+	import std.conv : text;
+	
+	const(char) *err = adbg_error_message();
+	
+	throw new Exception(
+		text(msg,": ", fromStringz(err)),
+		file, line);
+}
+
+unittest {
+	enum SRC = "tests/easy-target.d";
+	version (Windows) enum EXEC="easy-target.exe";
+	else              enum EXEC="./easy-target";
+	
+	import std.file : exists;
+	
+	// 0. Check if target exists
+	//    Unbothered to detect dmd/gdc/ldc and perform a compile
+	//    Do that yourself
+	if (exists(EXEC) == false) {
+		import std.stdio : writeln;
+		writeln("easy: target does not exist");
+		writeln("easy: compile '", SRC, "' as '", EXEC, "'");
+		writeln("easy: then re-run this test");
+		return;
+	}
+	
+	// 1. Create EZ instance
+	adbg_easy_t *ez = adbg_easy_create();
+	enforce(ez != null, "adbg_easy_create");
+	
+	// 2. Spawn executable
+	enforce(adbg_easy_spawn(ez, EXEC) == 0, "adbg_easy_spawn");
+}

--- a/tests/easy.d
+++ b/tests/easy.d
@@ -3,17 +3,20 @@ module tests.easy;
 import adbg.easy;
 
 
-void enforce(bool cond, string msg,
+void enforce(bool cond, string func,
 	size_t line = __LINE__, string file = __FILE__) {
 	if (cond) return;
 	
 	import std.string : fromStringz;
 	import std.conv : text;
 	
-	const(char) *err = adbg_error_message();
+	const(char) *aerr = adbg_error_message();
+	int acode = adbg_error_code();
+	int aline = adbg_error_line();
+	const(char)* afunc = adbg_error_function();
 	
 	throw new Exception(
-		text(msg,": ", fromStringz(err)),
+		text(func,": (", acode, "@", fromStringz(afunc), ":", aline, ") ", fromStringz(aerr)),
 		file, line);
 }
 
@@ -35,7 +38,7 @@ unittest {
 		return;
 	}
 	
-	// 1. Create EZ instance
+	// 1. Create easy instance
 	adbg_easy_t *ez = adbg_easy_create();
 	enforce(ez != null, "adbg_easy_create");
 	

--- a/tests/threading.d
+++ b/tests/threading.d
@@ -8,10 +8,10 @@ int threadfunc0(__osthread_t *thread, void *data) {
 	return 0;
 }
 unittest {
-	__osthread_t *t = osthrnew(&threadfunc0);
+	__osthread_t *t = os_thread_new(&threadfunc0);
 	assert(t, "t == NULL");
 	int code;
-	assert(osthrjoin(t, &code) == 0, "osthrjoin(t) != 0");
+	assert(os_thread_join(t, &code) == 0, "os_thread_join(t) != 0");
 	assert(code == 0, "code != 0");
 }
 
@@ -23,10 +23,10 @@ int threadfunc1(__osthread_t *thread, void *data) {
 	return 1;
 }
 unittest {
-	__osthread_t *t = osthrnew(&threadfunc1);
+	__osthread_t *t = os_thread_new(&threadfunc1);
 	assert(t, "t == NULL");
 	int code;
-	assert(osthrjoin(t, &code) == 0, "osthrjoin(t) != 0");
+	assert(os_thread_join(t, &code) == 0, "os_thread_join(t) != 0");
 	assert(code == 1, "code != 1");
 }
 
@@ -42,10 +42,10 @@ int threadfunc2(__osthread_t *thread, void *data) {
 }
 unittest {
 	__gshared int a = FUNC2DATA0;
-	__osthread_t *t = osthrnew(&threadfunc2, &a);
+	__osthread_t *t = os_thread_new(&threadfunc2, &a);
 	assert(t, "t == NULL");
 	int code;
-	assert(osthrjoin(t, &code) == 0, "osthrjoin(t) != 0");
+	assert(os_thread_join(t, &code) == 0, "os_thread_join(t) != 0");
 	assert(code == 0, "code != 0");
 	assert(a == FUNC2DATA1, "a != FUNC2DATA1");
 }
@@ -62,10 +62,10 @@ int threadfunc3(__osthread_t *thread, void *data) {
 }
 unittest {
 	__gshared int a = FUNC3DATA0;
-	__osthread_t *t = osthrnew(&threadfunc3, &a);
+	__osthread_t *t = os_thread_new(&threadfunc3, &a);
 	assert(t, "t == NULL");
 	int code;
-	assert(osthrjoin(t, &code) == 0, "osthrjoin(t) != 0");
+	assert(os_thread_join(t, &code) == 0, "os_thread_join(t) != 0");
 	assert(code == 1, "code != 1");
 	assert(a == FUNC3DATA1, "a != FUNC3DATA1");
 }
@@ -76,17 +76,16 @@ int threadfunc4(__osthread_t *thread, void *data) {
 	assert(thread);
 	assert(data == null);
 	// busy loop
-	while (true) {
-		if (osthrstatus(thread) & __OSTHREAD_CANCELED)
-			return 1;
-	}
-	return 0;
+	L:
+	if (osthrstatus(thread) & __OSTHREAD_CANCELED)
+		return 1;
+	goto L;
 }
 unittest {
-	__osthread_t *t = osthrnew(&threadfunc4);
+	__osthread_t *t = os_thread_new(&threadfunc4);
 	assert(t, "t == NULL");
-	osthrcancel(t);
+	os_thread_cancel(t);
 	int code;
-	assert(osthrjoin(t, &code) == 0, "osthrjoin(t) != 0");
+	assert(os_thread_join(t, &code) == 0, "os_thread_join(t) != 0");
 	assert(code == 1, "code != 1");
 }

--- a/tests/threading.d
+++ b/tests/threading.d
@@ -1,0 +1,59 @@
+import adbg.os.threads;
+
+// Expects no data, returns 0
+extern (C)
+int threadfunc0(__osthread_t *thread, void *data) {
+	assert(data == null);
+	return 0;
+}
+unittest {
+	__osthread_t *t = osthrnew(&threadfunc0);
+	assert(t, "t == NULL");
+	assert(osthrjoin(t) == 0, "osthrjoin(t) != 0");
+}
+
+// Expects no data, returns 1
+extern (C)
+int threadfunc1(__osthread_t *thread, void *data) {
+	assert(data == null);
+	return 1;
+}
+unittest {
+	__osthread_t *t = osthrnew(&threadfunc1);
+	assert(t, "t == NULL");
+	assert(osthrjoin(t) == 1, "osthrjoin(t) != 1");
+}
+
+// Expects data, returns 0
+enum FUNC2DATA0 = 3;
+enum FUNC2DATA1 = 300;
+extern (C)
+int threadfunc2(__osthread_t *thread, void *data) {
+	assert(data);
+	*cast(int*)data = FUNC2DATA1;
+	return 0;
+}
+unittest {
+	__gshared int a = FUNC2DATA0;
+	__osthread_t *t = osthrnew(&threadfunc2, &a);
+	assert(t, "t == NULL");
+	assert(osthrjoin(t) == 0, "osthrjoin(t) != 0");
+	assert(a == FUNC2DATA1, "a != FUNC2DATA1");
+}
+
+// Expects data, returns 1
+enum FUNC3DATA0 = 5;
+enum FUNC3DATA1 = 500;
+extern (C)
+int threadfunc3(__osthread_t *thread, void *data) {
+	assert(data);
+	*cast(int*)data = FUNC3DATA1;
+	return 1;
+}
+unittest {
+	__gshared int a = FUNC3DATA0;
+	__osthread_t *t = osthrnew(&threadfunc3, &a);
+	assert(t, "t == NULL");
+	assert(osthrjoin(t) == 1, "osthrjoin(t) != 1");
+	assert(a == FUNC3DATA1, "a != FUNC3DATA1");
+}

--- a/tests/threading.d
+++ b/tests/threading.d
@@ -1,27 +1,33 @@
 import adbg.os.threads;
 
-// Expects no data, returns 0
+// Expects no data, return 0
 extern (C)
 int threadfunc0(__osthread_t *thread, void *data) {
+	assert(thread);
 	assert(data == null);
 	return 0;
 }
 unittest {
 	__osthread_t *t = osthrnew(&threadfunc0);
 	assert(t, "t == NULL");
-	assert(osthrjoin(t) == 0, "osthrjoin(t) != 0");
+	int code;
+	assert(osthrjoin(t, &code) == 0, "osthrjoin(t) != 0");
+	assert(code == 0, "code != 0");
 }
 
-// Expects no data, returns 1
+// Expects no data, return 1
 extern (C)
 int threadfunc1(__osthread_t *thread, void *data) {
+	assert(thread);
 	assert(data == null);
 	return 1;
 }
 unittest {
 	__osthread_t *t = osthrnew(&threadfunc1);
 	assert(t, "t == NULL");
-	assert(osthrjoin(t) == 1, "osthrjoin(t) != 1");
+	int code;
+	assert(osthrjoin(t, &code) == 0, "osthrjoin(t) != 0");
+	assert(code == 1, "code != 1");
 }
 
 // Expects data, returns 0
@@ -29,6 +35,7 @@ enum FUNC2DATA0 = 3;
 enum FUNC2DATA1 = 300;
 extern (C)
 int threadfunc2(__osthread_t *thread, void *data) {
+	assert(thread);
 	assert(data);
 	*cast(int*)data = FUNC2DATA1;
 	return 0;
@@ -37,7 +44,9 @@ unittest {
 	__gshared int a = FUNC2DATA0;
 	__osthread_t *t = osthrnew(&threadfunc2, &a);
 	assert(t, "t == NULL");
-	assert(osthrjoin(t) == 0, "osthrjoin(t) != 0");
+	int code;
+	assert(osthrjoin(t, &code) == 0, "osthrjoin(t) != 0");
+	assert(code == 0, "code != 0");
 	assert(a == FUNC2DATA1, "a != FUNC2DATA1");
 }
 
@@ -46,6 +55,7 @@ enum FUNC3DATA0 = 5;
 enum FUNC3DATA1 = 500;
 extern (C)
 int threadfunc3(__osthread_t *thread, void *data) {
+	assert(thread);
 	assert(data);
 	*cast(int*)data = FUNC3DATA1;
 	return 1;
@@ -54,6 +64,29 @@ unittest {
 	__gshared int a = FUNC3DATA0;
 	__osthread_t *t = osthrnew(&threadfunc3, &a);
 	assert(t, "t == NULL");
-	assert(osthrjoin(t) == 1, "osthrjoin(t) != 1");
+	int code;
+	assert(osthrjoin(t, &code) == 0, "osthrjoin(t) != 0");
+	assert(code == 1, "code != 1");
 	assert(a == FUNC3DATA1, "a != FUNC3DATA1");
+}
+
+// Test cancellation
+extern (C)
+int threadfunc4(__osthread_t *thread, void *data) {
+	assert(thread);
+	assert(data == null);
+	// busy loop
+	while (true) {
+		if (osthrstatus(thread) & __OSTHREAD_CANCELED)
+			return 1;
+	}
+	return 0;
+}
+unittest {
+	__osthread_t *t = osthrnew(&threadfunc4);
+	assert(t, "t == NULL");
+	osthrcancel(t);
+	int code;
+	assert(osthrjoin(t, &code) == 0, "osthrjoin(t) != 0");
+	assert(code == 1, "code != 1");
 }


### PR DESCRIPTION
Introduce the Easy API with a partial rewrite.

The Easy API is a new set of modules that features a debug loop using message-based communication underneath. It will be something similar to libcurl's Easy interface, which will help manage remote processes and ease the integration process for Aliceserver in a multithread environment.

Breaking changes include mostly the debugger module, which gets rid of callbacks to state an example. Removing callbacks help with locality (otherwise, it's sync hell across several callbacks). However, callback(s) will be provided with the Easy API, because the event thread will be separated from the debugger thread.

There are other changes coming that removes some older cruft and hacks.

In summary:
- Introduce the Easy API via the `adbg.easy` module.
- Introduce thread, mutex, semaphore wrappers for internal use.
- Add `adbg.util.mailbox` for messages-passing for internal use.
- Redo the terminal library to avoid depending on `stderr` (a recurring issue regarding linking with older compilers on Windows).
- Make error module thread-safe(r) (by using TLS).
- Remove process hacks introduced in `adbg.debugger`.

It'll be a very messy, but overdue, PR.